### PR TITLE
Rebuild the AirPlay sidebar as one glass card

### DIFF
--- a/docs/superpowers/plans/2026-08-30-sidebar-liquid-glass.md
+++ b/docs/superpowers/plans/2026-08-30-sidebar-liquid-glass.md
@@ -1,0 +1,683 @@
+# Sidebar Liquid Glass Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rebuild the AirPlay sidebar tab as a single translucent glass card with one phase-driven primary action, elapsed time, and a persistent subtitle line, in both macOS appearances.
+
+**Architecture:** Two derived fields (`duration`, `subs`) are added to the existing `stateForPage()` payload in `plugin/main.js`; everything else is a rewrite of the markup, CSS, and `render()` function inside `plugin/sidebar.html`. The muted-mirror sync logic in that page is preserved verbatim. The Go helper and its event protocol are untouched.
+
+**Tech Stack:** Plain ES5-style JavaScript in a `WKWebView` (`plugin/sidebar.html`), plain JavaScript in a `JSContext` (`plugin/main.js`), `node --test` for the pure-function and runtime tests.
+
+Spec: `docs/superpowers/specs/2026-08-30-sidebar-liquid-glass-design.md`
+
+## Global Constraints
+
+- **Everything ships in `plugin/sidebar.html`.** `packaging/pack.sh:101` copies an explicit three-file list — `Info.json`, `plugin/main.js`, `plugin/sidebar.html`. A new `sidebar.css` or `sidebar.js` would be silently omitted from the package and the sidebar would ship unstyled. Do not split the file.
+- **Never call `sidebar.*` from a `utils.exec` callback or promise.** IINA runs those off the main thread and `sidebar.show()` SIGABRTs the app. See the header comment in `plugin/main.js:1-4`.
+- **Accent is reserved for the affirmative action** — `Start casting`, `Send to TV`, `Try again`. `Stop casting` is always a neutral glass button.
+- **Preserve verbatim** in `plugin/sidebar.html`: `applySync()`, the `v.addEventListener("error", ...)` retry-once handler, the three `webkit*` listeners, the `tvState` polling block, and the teardown branch inside `render()`. These carry the muted-mirror contract from `docs/superpowers/specs/2026-08-30-native-controls-mirror-design.md`.
+- **Match the existing JS style** in both files: `var`, `function` expressions, no arrow functions, no template literals.
+- **No AirPlay device name exists.** WebKit exposes only the `webkitCurrentPlaybackTargetIsWireless` boolean. Never write UI that implies a named target.
+- Full test suite: `make test`. Plugin tests alone: `node --test 'plugin/tests/**/*.test.mjs'`.
+
+---
+
+### Task 1: `subtitleLabel` pure function
+
+**Files:**
+- Modify: `plugin/main.js` (add function after `selectTracks`, which ends at line 44; add to `module.exports` at line 184)
+- Test: `plugin/tests/main.test.mjs` (append)
+
+**Interfaces:**
+- Consumes: `selectTracks(trackList)`, already exported, returning `{ vcodec, acodec, achannels, vmap, amap, sub, subDropped }` or `null`. Its `sub` is `{ path, smap, lang, title }` or `null`.
+- Produces: `subtitleLabel(tracks)` → `{ label: string, warn: boolean }`. Task 2 calls it; Task 4 renders `label` and uses `warn` to pick the text color.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `plugin/tests/main.test.mjs`:
+
+```javascript
+test("subtitleLabel names the track by language", () => {
+  const tracks = selectTracks([
+    { type: "video", selected: true, codec: "hevc", "ff-index": 0 },
+    { type: "audio", selected: true, codec: "aac", "ff-index": 1 },
+    { type: "sub", selected: true, codec: "subrip", "ff-index": 2, lang: "eng" },
+  ]);
+  assert.deepEqual(subtitleLabel(tracks), { label: "Subtitles: eng", warn: false });
+});
+
+test("subtitleLabel falls back to the track title, then to On", () => {
+  const base = [
+    { type: "video", selected: true, codec: "hevc", "ff-index": 0 },
+    { type: "audio", selected: true, codec: "aac", "ff-index": 1 },
+  ];
+  const titled = selectTracks(base.concat([
+    { type: "sub", selected: true, codec: "subrip", "ff-index": 2, title: "Forced" },
+  ]));
+  assert.equal(subtitleLabel(titled).label, "Subtitles: Forced");
+
+  const bare = selectTracks(base.concat([
+    { type: "sub", selected: true, codec: "subrip", "ff-index": 2 },
+  ]));
+  assert.equal(subtitleLabel(bare).label, "Subtitles: On");
+});
+
+test("subtitleLabel warns when the subtitle track was dropped", () => {
+  const tracks = selectTracks([
+    { type: "video", selected: true, codec: "hevc", "ff-index": 0 },
+    { type: "audio", selected: true, codec: "aac", "ff-index": 1 },
+    { type: "sub", selected: true, codec: "hdmv_pgs_subtitle", "ff-index": 2 },
+  ]);
+  assert.deepEqual(subtitleLabel(tracks),
+    { label: "Subtitles not supported", warn: true });
+});
+
+test("subtitleLabel reports no subtitles when none is selected", () => {
+  const tracks = selectTracks([
+    { type: "video", selected: true, codec: "hevc", "ff-index": 0 },
+    { type: "audio", selected: true, codec: "aac", "ff-index": 1 },
+  ]);
+  assert.deepEqual(subtitleLabel(tracks), { label: "No subtitles", warn: false });
+});
+
+test("subtitleLabel is empty when there are no castable tracks", () => {
+  assert.deepEqual(subtitleLabel(null), { label: "", warn: false });
+});
+```
+
+Add `subtitleLabel` to the destructured `require` on line 5 of that file:
+
+```javascript
+const { selectTracks, subtitleLabel, parseHelperEvents, pluginsDirFromDataDir, isValidPid, hasURLScheme, normalizeSource } = require("../main.js");
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `node --test plugin/tests/main.test.mjs`
+Expected: FAIL — `TypeError: subtitleLabel is not a function`
+
+- [ ] **Step 3: Write the implementation**
+
+In `plugin/main.js`, directly after the closing brace of `selectTracks` (line 44) and before `parseHelperEvents`:
+
+```javascript
+// selectTracks already decided what happens to subtitles; this just names the
+// decision for the sidebar. Before the redesign that answer existed only as a
+// one-shot OSD flash, which vanished before it could be read.
+function subtitleLabel(tracks) {
+  if (!tracks) return { label: "", warn: false };
+  if (tracks.subDropped) return { label: "Subtitles not supported", warn: true };
+  if (!tracks.sub) return { label: "No subtitles", warn: false };
+  return { label: "Subtitles: " + (tracks.sub.lang || tracks.sub.title || "On"),
+           warn: false };
+}
+```
+
+In the `module.exports` block, after the `selectTracks` line:
+
+```javascript
+    subtitleLabel: subtitleLabel,
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `node --test plugin/tests/main.test.mjs`
+Expected: PASS, all tests in the file
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugin/main.js plugin/tests/main.test.mjs
+git commit -m "feat: name the subtitle decision with subtitleLabel"
+```
+
+---
+
+### Task 2: Derive `duration` and `subs` in `stateForPage()`
+
+**Files:**
+- Modify: `plugin/main.js:223-231` (the `stateForPage` function)
+- Test: `plugin/tests/runtime.test.mjs` (append)
+
+**Interfaces:**
+- Consumes: `subtitleLabel(tracks)` from Task 1.
+- Produces: the `state` payload posted to the page gains `duration: number` (seconds, `0` when unknown) and `subs: { label: string, warn: boolean }`. Task 4 reads both.
+
+The fake `iina` in `plugin/tests/runtime.test.mjs` already returns `120` for `mpv.getNumber("duration")` and the harness's `trackList` for `mpv.getNative`, so no harness changes are needed. `p.state()` returns the most recently posted state payload.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `plugin/tests/runtime.test.mjs`:
+
+```javascript
+test("state carries duration and a subtitle label", () => {
+  const p = loadPlugin();
+  p.clickMenu();
+  const s = p.state();
+  assert.equal(s.duration, 120);
+  assert.deepEqual(s.subs, { label: "No subtitles", warn: false });
+});
+
+test("state reports the selected subtitle track", () => {
+  const p = loadPlugin({ tracks: [
+    { type: "video", selected: true, codec: "hevc", "ff-index": 0 },
+    { type: "audio", selected: true, codec: "aac", "ff-index": 1, "demux-channel-count": 2 },
+    { type: "sub", selected: true, codec: "subrip", "ff-index": 2, lang: "eng" },
+  ] });
+  p.clickMenu();
+  assert.equal(p.state().subs.label, "Subtitles: eng");
+});
+
+test("subtitle label is available before any cast starts", () => {
+  const p = loadPlugin();
+  p.clickMenu();
+  p.send("stop");
+  const s = p.state();
+  assert.equal(s.phase, "idle");
+  assert.equal(s.subs.label, "No subtitles");
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `node --test plugin/tests/runtime.test.mjs`
+Expected: FAIL — `s.duration` is `undefined`, `s.subs` is `undefined`
+
+- [ ] **Step 3: Write the implementation**
+
+Replace `stateForPage` in `plugin/main.js` (currently lines 223-231) with:
+
+```javascript
+  function stateForPage() {
+    // duration and subs are derived here, not stored on `state`: selectTracks
+    // otherwise runs only at cast start, so a stored label would be empty
+    // before the first cast — exactly when the user is deciding whether to
+    // cast — and would go stale if the subtitle track changed mid-session.
+    // Safe to read mpv here: every caller is a sidebar.onMessage handler,
+    // which IINA runs on the main thread.
+    return {
+      phase: state.phase, url: state.url, pct: state.pct, msg: state.msg,
+      duration: mpv.getNumber("duration") || 0,
+      subs: subtitleLabel(selectTracks(mpv.getNative("track-list") || [])),
+      sync: mirror === null ? null : {
+        seq: mirror.seq, paused: mirror.paused,
+        seekTo: mirror.seekTo, startPos: mirror.startPos,
+      },
+    };
+  }
+```
+
+- [ ] **Step 4: Run the full plugin test suite to verify it passes**
+
+Run: `node --test 'plugin/tests/**/*.test.mjs'`
+Expected: PASS, including the pre-existing runtime and mirror tests
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugin/main.js plugin/tests/runtime.test.mjs
+git commit -m "feat: send duration and subtitle status to the sidebar page"
+```
+
+---
+
+### Task 3: The glass card — markup and tokens
+
+**Files:**
+- Modify: `plugin/sidebar.html` (the `<style>` block and the `#wrap` markup; the `<script>` gains new element handles and a rewritten `render()`)
+
+**Interfaces:**
+- Consumes: the `state` payload from Task 2 (`phase`, `pct`, `msg`, `url`, `sync`, `duration`, `subs`).
+- Produces: DOM ids that Task 4 drives — `#dot`, `#headline`, `#sub`, `#bar`, `#fill`, `#times`, `#elapsed`, `#total`, `#primary`, `#secondary`. Task 4 replaces the body of `render()` and both button handlers.
+
+This task lands a page that looks right and still casts. Task 4 makes every row of the state table correct.
+
+- [ ] **Step 1: Replace the `<style>` block**
+
+In `plugin/sidebar.html`, replace everything between `<style>` and `</style>` with:
+
+```css
+  :root {
+    --glass-fill-top: rgba(0, 0, 0, 0.06);
+    --glass-fill-bot: rgba(0, 0, 0, 0.02);
+    --glass-edge: rgba(0, 0, 0, 0.08);
+    --glass-spec: rgba(255, 255, 255, 0.70);
+    --track: rgba(0, 0, 0, 0.10);
+    --neutral-btn: rgba(0, 0, 0, 0.06);
+    --ink: #1C1C1E;
+    --ink-2: rgba(0, 0, 0, 0.55);
+    --accent: #007AFF;
+    --accent-hi: #40A0FF;
+    --warn: #8A5B06;
+    --shade: rgba(255, 255, 255, 0.45);
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --glass-fill-top: rgba(255, 255, 255, 0.13);
+      --glass-fill-bot: rgba(255, 255, 255, 0.035);
+      --glass-edge: rgba(255, 255, 255, 0.10);
+      --glass-spec: rgba(255, 255, 255, 0.22);
+      --track: rgba(255, 255, 255, 0.13);
+      --neutral-btn: rgba(255, 255, 255, 0.09);
+      --ink: #F2F3F5;
+      --ink-2: rgba(255, 255, 255, 0.58);
+      --accent: #0A84FF;
+      --accent-hi: #3D9BFF;
+      --warn: #F0C169;
+      --shade: rgba(255, 255, 255, 0.90);
+    }
+  }
+
+  html, body { margin: 0; background: transparent; color: var(--ink);
+    font: 13px/1.45 -apple-system, BlinkMacSystemFont, sans-serif;
+    -webkit-font-smoothing: antialiased; }
+  video { width: 1px; height: 1px; opacity: 0.01; position: absolute; }
+  #wrap { padding: 12px; }
+
+  #card {
+    display: flex; flex-direction: column; gap: 12px;
+    padding: 14px; border-radius: 16px;
+    background: linear-gradient(180deg, var(--glass-fill-top), var(--glass-fill-bot));
+    -webkit-backdrop-filter: blur(22px) saturate(180%);
+    backdrop-filter: blur(22px) saturate(180%);
+    border: 1px solid var(--glass-edge);
+    box-shadow: inset 0 1px 0 var(--glass-spec), 0 8px 22px rgba(0, 0, 0, 0.16);
+  }
+
+  .row { display: flex; align-items: center; gap: 8px; }
+  .spread { justify-content: space-between; }
+  .grow { min-width: 0; }
+
+  #head { color: var(--ink-2); }
+  #head svg { width: 16px; height: 16px; flex: none; }
+  #cap { font-size: 10px; font-weight: 600; letter-spacing: 0.09em;
+    text-transform: uppercase; }
+
+  #dot { width: 6px; height: 6px; border-radius: 50%; flex: none;
+    background: transparent; }
+  #dot.busy { background: #E0A93C; box-shadow: 0 0 7px rgba(224, 169, 60, 0.75); }
+  #dot.live { background: #30C24E; box-shadow: 0 0 7px rgba(48, 194, 78, 0.75); }
+  #dot.bad  { background: #E0523C; box-shadow: 0 0 7px rgba(224, 82, 60, 0.75); }
+
+  #headline { margin: 0; font-size: 15px; font-weight: 590;
+    letter-spacing: -0.01em; }
+  #sub { margin: 0; font-size: 12px; color: var(--ink-2); }
+  #sub.warn { color: var(--warn); }
+  #headline, #sub { overflow: hidden; text-overflow: ellipsis;
+    white-space: nowrap; }
+
+  #meter { display: flex; flex-direction: column; gap: 6px; }
+  #bar { height: 5px; border-radius: 3px; background: var(--track);
+    overflow: hidden; }
+  #fill { height: 100%; width: 0; border-radius: 3px;
+    background: linear-gradient(180deg, var(--accent-hi), var(--accent));
+    transition: width 0.4s cubic-bezier(0.32, 0.72, 0, 1); }
+  #fill.done { background: var(--shade); }
+  #times { font-size: 11.5px; color: var(--ink-2);
+    font-variant-numeric: tabular-nums; }
+
+  #actions { display: flex; flex-direction: column; gap: 6px; }
+  button { display: block; width: 100%; padding: 9px 12px; border: none;
+    border-radius: 11px; font: inherit; font-size: 13px; font-weight: 590;
+    cursor: pointer; color: var(--ink); background: var(--neutral-btn);
+    box-shadow: inset 0 1px 0 var(--glass-spec); }
+  button.accent { color: #fff;
+    background: linear-gradient(180deg, var(--accent-hi), var(--accent));
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35),
+                0 4px 12px rgba(10, 111, 232, 0.30); }
+  button.quiet { background: transparent; box-shadow: none;
+    color: var(--ink-2); font-weight: 500; font-size: 12.5px; padding: 5px; }
+  button:disabled { color: var(--ink-2); background: var(--neutral-btn);
+    box-shadow: none; cursor: default; opacity: 0.6; }
+  button:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+  .hide { display: none; }
+
+  @media (prefers-reduced-motion: reduce) { #fill { transition: none; } }
+```
+
+- [ ] **Step 2: Replace the `#wrap` markup**
+
+Replace the `<div id="wrap">…</div>` block (leave the `<video>` element that follows it exactly as it is) with:
+
+```html
+<div id="wrap">
+  <div id="card">
+    <div class="row spread" id="head">
+      <div class="row" style="gap:6px">
+        <svg viewBox="0 0 24 24" fill="none" aria-hidden="true"><rect x="2.4" y="3.4" width="19.2" height="13" rx="2.6" stroke="currentColor" stroke-width="1.6" opacity="0.75"/><path d="M12 14.4 17 21H7z" fill="currentColor"/></svg>
+        <span id="cap">AirPlay</span>
+      </div>
+      <span id="dot"></span>
+    </div>
+    <div class="grow">
+      <p id="headline">Preparing…</p>
+      <p id="sub"></p>
+    </div>
+    <div id="meter">
+      <div id="bar"><div id="fill"></div></div>
+      <div class="row spread" id="times">
+        <span id="elapsed"></span><span id="total"></span>
+      </div>
+    </div>
+    <div id="actions">
+      <button id="primary" type="button"></button>
+      <button id="secondary" type="button" class="quiet"></button>
+    </div>
+  </div>
+</div>
+```
+
+- [ ] **Step 3: Update the element handles**
+
+Replace the first block of `var` declarations at the top of the `<script>` — the six lines from `var v = document.getElementById("v");` through `var fill = document.getElementById("fill");` — with:
+
+```javascript
+  var v = document.getElementById("v");
+  var dot = document.getElementById("dot");
+  var headline = document.getElementById("headline");
+  var subEl = document.getElementById("sub");
+  var meter = document.getElementById("meter");
+  var fill = document.getElementById("fill");
+  var elapsedEl = document.getElementById("elapsed");
+  var totalEl = document.getElementById("total");
+  var primary = document.getElementById("primary");
+  var secondary = document.getElementById("secondary");
+```
+
+Leave every other `var` in that block (`loadedURL`, `retried`, `airplayAvailable`, `onTV`, `casting`, `appliedSeq`, `initialSeekPending`, `ended`) untouched, and add two new flags at the end of it:
+
+```javascript
+  var localErr = "";        // page-side media failure, distinct from state.msg
+  var primaryAct = "start"; // what #primary does: "start" | "pick" | "stop"
+```
+
+`localErr` replaces the removed `#err` paragraph. The `v.addEventListener("error", ...)` handler currently writes into `errEl`, which no longer exists — Step 4 rewires it.
+
+- [ ] **Step 4: Make the page compile and still cast**
+
+The old `render()`, `pick.onclick`, and `castBtn.onclick` reference `pick`, `castBtn`, `statusEl`, and `errEl`, which no longer exist. Replace `render()` with this interim version, which keeps the teardown and load branches intact, and replace both `onclick` assignments with the two handlers below. Task 4 rewrites the presentation half of `render()`.
+
+```javascript
+  function render(s) {
+    casting = s.phase === "starting" || s.phase === "ready" || s.phase === "packaged";
+    if (!casting && loadedURL) {
+      // main.js tore the cast down (helper died, file changed, TV ended):
+      // drop the stream locally too, or the element keeps AirPlaying a corpse.
+      v.pause(); v.removeAttribute("src"); v.load();
+      loadedURL = null; retried = false; onTV = false;
+      v.muted = true; appliedSeq = 0; ended = false; initialSeekPending = false;
+    }
+    applySync(s.sync);
+    present(s);
+    if ((s.phase === "ready" || s.phase === "packaged") && s.url && s.url !== loadedURL) {
+      loadedURL = s.url;
+      retried = false;
+      // -1, not 0: the mirror's very first sync (seq 0) carries the cast's
+      // initial paused snapshot, and applySync's `sync.seq > appliedSeq` gate
+      // would otherwise never let it through, autoplaying over a paused mpv.
+      appliedSeq = -1; ended = false; initialSeekPending = true;
+      v.src = s.url;
+      v.play().catch(function () {});
+    }
+  }
+
+  function present(s) {
+    headline.textContent = casting ? "Casting" : "Not casting";
+    subEl.textContent = (s.subs && s.subs.label) || "";
+    fill.style.width = (s.pct || 0) + "%";
+    primary.textContent = casting ? "Send to TV" : "Start casting";
+    secondary.textContent = "Stop casting";
+  }
+```
+
+```javascript
+  primary.onclick = function () {
+    if (casting) { if (v.webkitShowPlaybackTargetPicker) v.webkitShowPlaybackTargetPicker(); }
+    else { localErr = ""; iina.postMessage("start", {}); }
+  };
+  secondary.onclick = function () {
+    v.pause(); v.removeAttribute("src"); v.load();
+    loadedURL = null; retried = false; onTV = false;
+    v.muted = true; appliedSeq = 0; ended = false; initialSeekPending = false;
+    localErr = "";
+    iina.postMessage("stop", {});
+  };
+```
+
+Two existing listeners still reference removed elements. Update the availability listener, which assigns `pick.disabled`:
+
+```javascript
+  v.addEventListener("webkitplaybacktargetavailabilitychanged", function (ev) {
+    airplayAvailable = ev.availability === "available";
+  });
+```
+
+And the media-error listener, whose `else` branch writes into `errEl`. Keep the retry-once behavior exactly as it is; only the reporting changes:
+
+```javascript
+  v.addEventListener("error", function () {
+    if (!loadedURL) return;                // src cleared by a stop, not a real failure
+    if (!retried) {                        // retry exactly once (docs/prototype.md)
+      retried = true;
+      v.src = loadedURL;
+      v.play().catch(function () {});
+    } else {
+      localErr = "Stream failed to load (media error " +
+        (v.error ? v.error.code : "?") + ").";
+    }
+  });
+```
+
+Clear `localErr` wherever a fresh attempt begins — in `teardownLocal()` (Task 4) and in the `"start"` branch of the primary handler below.
+
+- [ ] **Step 5: Verify nothing regressed and the page loads**
+
+Run: `make test`
+Expected: PASS — this task touches no tested code, so a failure means something else broke.
+
+Then load the plugin in IINA (`make dev`, restart IINA, open a file, run the **Cast to TV** menu item) and confirm: the glass card renders, the buttons work, and a cast still reaches the TV. Check both appearances via System Settings → Appearance.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add plugin/sidebar.html
+git commit -m "feat: rebuild the sidebar as a glass card in both appearances"
+```
+
+---
+
+### Task 4: The state table
+
+**Files:**
+- Modify: `plugin/sidebar.html` (the `present()` function, the two button handlers, and the `webkitcurrentplaybacktargetiswirelesschanged` listener)
+
+**Interfaces:**
+- Consumes: `#dot`, `#headline`, `#sub`, `#meter`, `#fill`, `#elapsed`, `#total`, `#primary`, `#secondary` from Task 3; `s.duration` and `s.subs` from Task 2; the page-local `casting`, `onTV`, and `airplayAvailable` flags.
+- Produces: nothing downstream. This is the last code task.
+
+- [ ] **Step 1: Add the time formatter**
+
+Insert above `present()`:
+
+```javascript
+  function clock(sec) {
+    if (!(sec > 0)) return "0:00";
+    var t = Math.floor(sec), h = Math.floor(t / 3600),
+        m = Math.floor((t % 3600) / 60), s = t % 60;
+    var mm = h > 0 && m < 10 ? "0" + m : String(m);
+    return (h > 0 ? h + ":" : "") + mm + ":" + (s < 10 ? "0" + s : s);
+  }
+```
+
+- [ ] **Step 2: Replace `present()` with the full state table**
+
+```javascript
+  // One row of the spec's state table per branch. `act` is what the primary
+  // button does when clicked: "start", "pick", or "stop".
+  function present(s) {
+    var subs = s.subs || { label: "", warn: false };
+    var r;
+    if (s.phase === "error" || localErr) {
+      // A page-side media failure is still a failed cast from the user's side,
+      // so it takes the same row. state.msg wins when both are set: main.js
+      // knows why the pipeline died, the <video> element only knows it choked.
+      r = { dot: "bad", headline: "Couldn't cast", sub: s.msg || localErr,
+            warn: true, meter: false, pct: 0, done: false,
+            primary: "Try again", act: "start", accent: true, off: false,
+            secondary: casting ? "Stop casting" : null };
+    } else if (!casting) {
+      r = { dot: "", headline: "Not casting", sub: subs.label,
+            warn: subs.warn, meter: false, pct: 0, done: false,
+            primary: "Start casting", act: "start", accent: true, off: false,
+            secondary: null };
+    } else if (s.phase === "starting") {
+      r = { dot: "busy", headline: "Packaging", sub: subs.label,
+            warn: subs.warn, meter: true, pct: s.pct || 0, done: false,
+            primary: "Send to TV", act: "pick", accent: true, off: true,
+            secondary: "Cancel" };
+    } else if (onTV) {
+      var pos = v.currentTime || 0;
+      r = { dot: "live", headline: "Playing on TV", sub: subs.label,
+            warn: subs.warn, meter: true, done: false,
+            pct: s.duration > 0 ? (pos / s.duration) * 100 : 0,
+            primary: "Stop casting", act: "stop", accent: false, off: false,
+            secondary: "Send to another TV" };
+    } else {
+      r = { dot: "", headline: "Ready to send",
+            sub: airplayAvailable ? subs.label : "Waiting for AirPlay devices…",
+            warn: airplayAvailable && subs.warn,
+            meter: true, pct: 100, done: true,
+            primary: "Send to TV", act: "pick", accent: true,
+            off: !airplayAvailable, secondary: "Stop casting" };
+    }
+
+    dot.className = r.dot;
+    headline.textContent = r.headline;
+    subEl.textContent = r.sub;
+    subEl.title = r.sub;                 // the full string, when it ellipsizes
+    subEl.className = r.warn ? "warn" : "";
+
+    meter.className = r.meter ? "" : "hide";
+    fill.style.width = Math.max(0, Math.min(100, r.pct)) + "%";
+    fill.className = r.done ? "done" : "";
+    elapsedEl.textContent = onTV ? clock(v.currentTime || 0)
+                          : s.phase === "starting" ? Math.round(s.pct || 0) + "%"
+                          : "Packaged";
+    totalEl.textContent = s.duration > 0 ? clock(s.duration) : "";
+
+    primary.textContent = r.primary;
+    primary.disabled = r.off;
+    primary.className = r.accent && !r.off ? "accent" : "";
+    primaryAct = r.act;
+
+    secondary.textContent = r.secondary || "";
+    secondary.className = r.secondary ? "quiet" : "quiet hide";
+  }
+```
+
+- [ ] **Step 3: Dispatch the primary action**
+
+`primaryAct` was declared in Task 3, Step 3. Replace the two button handlers from Task 3 with:
+
+```javascript
+  function teardownLocal() {
+    v.pause(); v.removeAttribute("src"); v.load();
+    loadedURL = null; retried = false; onTV = false;
+    v.muted = true; appliedSeq = 0; ended = false; initialSeekPending = false;
+    localErr = "";
+  }
+  function showPicker() {
+    if (v.webkitShowPlaybackTargetPicker) v.webkitShowPlaybackTargetPicker();
+  }
+  primary.onclick = function () {
+    if (primaryAct === "pick") showPicker();
+    else if (primaryAct === "stop") { teardownLocal(); iina.postMessage("stop", {}); }
+    else { localErr = ""; iina.postMessage("start", {}); }
+  };
+  secondary.onclick = function () {
+    // "Send to another TV" while playing; "Cancel"/"Stop casting" otherwise.
+    if (onTV) { showPicker(); return; }
+    teardownLocal();
+    iina.postMessage("stop", {});
+  };
+```
+
+Then replace the teardown block inside `render()` with a call to the shared helper, so the same eight assignments do not live in three places:
+
+```javascript
+    if (!casting && loadedURL) {
+      // main.js tore the cast down (helper died, file changed, TV ended):
+      // drop the stream locally too, or the element keeps AirPlaying a corpse.
+      teardownLocal();
+    }
+```
+
+- [ ] **Step 4: Keep the elapsed time ticking**
+
+`render()` runs only when `main.js` posts state, which the page requests every 500ms — fast enough for a seconds display, so no extra timer is needed. Confirm the existing `setInterval` block at the bottom of the file still posts `getState` every 500ms and is otherwise unmodified.
+
+- [ ] **Step 5: Run the test suite**
+
+Run: `make test`
+Expected: PASS — no tested code changed in this task; a failure means Task 2's changes regressed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add plugin/sidebar.html
+git commit -m "feat: drive the sidebar card from the cast state table"
+```
+
+---
+
+### Task 5: Manual verification against the state table
+
+**Files:**
+- Modify: none (fixes only, if the pass finds something)
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-4.
+- Produces: a verified build.
+
+There is no DOM harness for this page — it renders in a `WKWebView` inside IINA — so this pass is the only coverage the render path gets. Do not skip it.
+
+- [ ] **Step 1: Install the dev build**
+
+```bash
+make dev
+```
+
+Restart IINA, open a video file with a text subtitle track selected, and run the **Cast to TV** menu item.
+
+- [ ] **Step 2: Walk every row of the state table in dark appearance**
+
+Confirm each, in System Settings → Appearance → Dark:
+
+- Before casting: dot hidden, "Not casting", subtitle line populated, no progress bar, one accent "Start casting" button, no secondary.
+- While packaging: amber dot, "Packaging", percentage on the left of the times row, duration on the right, "Send to TV" disabled, "Cancel" below it.
+- Packaged, no Apple TV powered on: "Waiting for AirPlay devices…", "Send to TV" disabled.
+- Packaged, Apple TV available: "Ready to send", accent "Send to TV" enabled, "Stop casting" below.
+- Playing on the TV: green dot, "Playing on TV", elapsed time ticking, **"Stop casting" is neutral, not blue**, "Send to another TV" below it.
+- Error (cast a file with no audio track): red dot, "Couldn't cast", the message text, accent "Try again".
+- Page-side media error: the retry-once path is hard to force deliberately; if you do see "Stream failed to load (media error …)", it must appear on the error row, not as a bare line, and "Try again" must recover.
+
+- [ ] **Step 3: Repeat in light appearance**
+
+Switch to System Settings → Appearance → Light and walk the same six rows. The card must stay legible — dark text on the light sidebar material, no white-on-white.
+
+- [ ] **Step 4: Check the narrow-sidebar case**
+
+Drag the IINA sidebar as narrow as it goes. The headline and subtitle line must ellipsize rather than wrap or overflow; both buttons stay full width; the times row must not collide.
+
+- [ ] **Step 5: Confirm the mirror still works**
+
+With a cast playing on the TV: press space in IINA (the TV pauses), scrub the IINA seek bar (the TV seeks), and pause from the Apple TV remote (IINA's play/pause icon follows). This is the muted-mirror contract; Tasks 3 and 4 must not have disturbed it.
+
+- [ ] **Step 6: Commit any fixes**
+
+```bash
+git add plugin/sidebar.html
+git commit -m "fix: <what the verification pass turned up>"
+```
+
+If the pass found nothing, skip this step.

--- a/docs/superpowers/plans/2026-08-30-sidebar-liquid-glass.md
+++ b/docs/superpowers/plans/2026-08-30-sidebar-liquid-glass.md
@@ -30,7 +30,7 @@ Spec: `docs/superpowers/specs/2026-08-30-sidebar-liquid-glass-design.md`
 
 **Interfaces:**
 - Consumes: `selectTracks(trackList)`, already exported, returning `{ vcodec, acodec, achannels, vmap, amap, sub, subDropped }` or `null`. Its `sub` is `{ path, smap, lang, title }` or `null`.
-- Produces: `subtitleLabel(tracks)` → `{ label: string, warn: boolean }`. Task 2 calls it; Task 4 renders `label` and uses `warn` to pick the text color.
+- Produces: `subtitleLabel(tracks)` → `{ label: string, warn: boolean }`. Task 2 calls it; Task 3 renders `label` and uses `warn` to pick the text color.
 
 - [ ] **Step 1: Write the failing tests**
 
@@ -141,7 +141,7 @@ git commit -m "feat: name the subtitle decision with subtitleLabel"
 
 **Interfaces:**
 - Consumes: `subtitleLabel(tracks)` from Task 1.
-- Produces: the `state` payload posted to the page gains `duration: number` (seconds, `0` when unknown) and `subs: { label: string, warn: boolean }`. Task 4 reads both.
+- Produces: the `state` payload posted to the page gains `duration: number` (seconds, `0` when unknown) and `subs: { label: string, warn: boolean }`. Task 3 reads both.
 
 The fake `iina` in `plugin/tests/runtime.test.mjs` already returns `120` for `mpv.getNumber("duration")` and the harness's `trackList` for `mpv.getNative`, so no harness changes are needed. `p.state()` returns the most recently posted state payload.
 
@@ -221,16 +221,16 @@ git commit -m "feat: send duration and subtitle status to the sidebar page"
 
 ---
 
-### Task 3: The glass card — markup and tokens
+### Task 3: The glass card and its state table
 
 **Files:**
-- Modify: `plugin/sidebar.html` (the `<style>` block and the `#wrap` markup; the `<script>` gains new element handles and a rewritten `render()`)
+- Modify: `plugin/sidebar.html` (the `<style>` block, the `#wrap` markup, and the `<script>`)
 
 **Interfaces:**
-- Consumes: the `state` payload from Task 2 (`phase`, `pct`, `msg`, `url`, `sync`, `duration`, `subs`).
-- Produces: DOM ids that Task 4 drives — `#dot`, `#headline`, `#sub`, `#bar`, `#fill`, `#times`, `#elapsed`, `#total`, `#primary`, `#secondary`. Task 4 replaces the body of `render()` and both button handlers.
+- Consumes: the `state` payload from Task 2 — `phase`, `pct`, `msg`, `url`, `sync`, `duration`, `subs` (where `subs` is `{ label, warn }` from Task 1).
+- Produces: nothing downstream. This is the last code task.
 
-This task lands a page that looks right and still casts. Task 4 makes every row of the state table correct.
+This is one task because the markup, the CSS, and the render function cannot be separated without leaving the page broken between commits. Preserve `applySync()`, the three `webkit*` listeners, and the polling block at the bottom of the file — they carry the muted-mirror contract.
 
 - [ ] **Step 1: Replace the `<style>` block**
 
@@ -337,7 +337,7 @@ In `plugin/sidebar.html`, replace everything between `<style>` and `</style>` wi
 
 - [ ] **Step 2: Replace the `#wrap` markup**
 
-Replace the `<div id="wrap">…</div>` block (leave the `<video>` element that follows it exactly as it is) with:
+Replace the `<div id="wrap">…</div>` block. Leave the `<video>` element that follows it exactly as it is — its attributes carry the AirPlay opt-in.
 
 ```html
 <div id="wrap">
@@ -367,7 +367,7 @@ Replace the `<div id="wrap">…</div>` block (leave the `<video>` element that f
 </div>
 ```
 
-- [ ] **Step 3: Update the element handles**
+- [ ] **Step 3: Replace the element handles and add two flags**
 
 Replace the first block of `var` declarations at the top of the `<script>` — the six lines from `var v = document.getElementById("v");` through `var fill = document.getElementById("fill");` — with:
 
@@ -391,11 +391,34 @@ Leave every other `var` in that block (`loadedURL`, `retried`, `airplayAvailable
   var primaryAct = "start"; // what #primary does: "start" | "pick" | "stop"
 ```
 
-`localErr` replaces the removed `#err` paragraph. The `v.addEventListener("error", ...)` handler currently writes into `errEl`, which no longer exists — Step 4 rewires it.
+`localErr` replaces the removed `#err` paragraph.
 
-- [ ] **Step 4: Make the page compile and still cast**
+- [ ] **Step 4: Add the shared helpers**
 
-The old `render()`, `pick.onclick`, and `castBtn.onclick` reference `pick`, `castBtn`, `statusEl`, and `errEl`, which no longer exist. Replace `render()` with this interim version, which keeps the teardown and load branches intact, and replace both `onclick` assignments with the two handlers below. Task 4 rewrites the presentation half of `render()`.
+Insert these above `render()`. `teardownLocal` collects the eight-assignment reset that the old file repeated in three places.
+
+```javascript
+  function teardownLocal() {
+    v.pause(); v.removeAttribute("src"); v.load();
+    loadedURL = null; retried = false; onTV = false;
+    v.muted = true; appliedSeq = 0; ended = false; initialSeekPending = false;
+    localErr = "";
+  }
+  function showPicker() {
+    if (v.webkitShowPlaybackTargetPicker) v.webkitShowPlaybackTargetPicker();
+  }
+  function clock(sec) {
+    if (!(sec > 0)) return "0:00";
+    var t = Math.floor(sec), h = Math.floor(t / 3600),
+        m = Math.floor((t % 3600) / 60), s = t % 60;
+    var mm = h > 0 && m < 10 ? "0" + m : String(m);
+    return (h > 0 ? h + ":" : "") + mm + ":" + (s < 10 ? "0" + s : s);
+  }
+```
+
+- [ ] **Step 5: Rewrite `render()` and add `present()`**
+
+Replace the whole existing `render()` function with these two. The `casting` assignment, the teardown branch, the `applySync` call, and the new-URL branch keep their existing behavior and comments; only the presentation moves out into `present()`.
 
 ```javascript
   function render(s) {
@@ -403,9 +426,7 @@ The old `render()`, `pick.onclick`, and `castBtn.onclick` reference `pick`, `cas
     if (!casting && loadedURL) {
       // main.js tore the cast down (helper died, file changed, TV ended):
       // drop the stream locally too, or the element keeps AirPlaying a corpse.
-      v.pause(); v.removeAttribute("src"); v.load();
-      loadedURL = null; retried = false; onTV = false;
-      v.muted = true; appliedSeq = 0; ended = false; initialSeekPending = false;
+      teardownLocal();
     }
     applySync(s.sync);
     present(s);
@@ -421,97 +442,6 @@ The old `render()`, `pick.onclick`, and `castBtn.onclick` reference `pick`, `cas
     }
   }
 
-  function present(s) {
-    headline.textContent = casting ? "Casting" : "Not casting";
-    subEl.textContent = (s.subs && s.subs.label) || "";
-    fill.style.width = (s.pct || 0) + "%";
-    primary.textContent = casting ? "Send to TV" : "Start casting";
-    secondary.textContent = "Stop casting";
-  }
-```
-
-```javascript
-  primary.onclick = function () {
-    if (casting) { if (v.webkitShowPlaybackTargetPicker) v.webkitShowPlaybackTargetPicker(); }
-    else { localErr = ""; iina.postMessage("start", {}); }
-  };
-  secondary.onclick = function () {
-    v.pause(); v.removeAttribute("src"); v.load();
-    loadedURL = null; retried = false; onTV = false;
-    v.muted = true; appliedSeq = 0; ended = false; initialSeekPending = false;
-    localErr = "";
-    iina.postMessage("stop", {});
-  };
-```
-
-Two existing listeners still reference removed elements. Update the availability listener, which assigns `pick.disabled`:
-
-```javascript
-  v.addEventListener("webkitplaybacktargetavailabilitychanged", function (ev) {
-    airplayAvailable = ev.availability === "available";
-  });
-```
-
-And the media-error listener, whose `else` branch writes into `errEl`. Keep the retry-once behavior exactly as it is; only the reporting changes:
-
-```javascript
-  v.addEventListener("error", function () {
-    if (!loadedURL) return;                // src cleared by a stop, not a real failure
-    if (!retried) {                        // retry exactly once (docs/prototype.md)
-      retried = true;
-      v.src = loadedURL;
-      v.play().catch(function () {});
-    } else {
-      localErr = "Stream failed to load (media error " +
-        (v.error ? v.error.code : "?") + ").";
-    }
-  });
-```
-
-Clear `localErr` wherever a fresh attempt begins — in `teardownLocal()` (Task 4) and in the `"start"` branch of the primary handler below.
-
-- [ ] **Step 5: Verify nothing regressed and the page loads**
-
-Run: `make test`
-Expected: PASS — this task touches no tested code, so a failure means something else broke.
-
-Then load the plugin in IINA (`make dev`, restart IINA, open a file, run the **Cast to TV** menu item) and confirm: the glass card renders, the buttons work, and a cast still reaches the TV. Check both appearances via System Settings → Appearance.
-
-- [ ] **Step 6: Commit**
-
-```bash
-git add plugin/sidebar.html
-git commit -m "feat: rebuild the sidebar as a glass card in both appearances"
-```
-
----
-
-### Task 4: The state table
-
-**Files:**
-- Modify: `plugin/sidebar.html` (the `present()` function, the two button handlers, and the `webkitcurrentplaybacktargetiswirelesschanged` listener)
-
-**Interfaces:**
-- Consumes: `#dot`, `#headline`, `#sub`, `#meter`, `#fill`, `#elapsed`, `#total`, `#primary`, `#secondary` from Task 3; `s.duration` and `s.subs` from Task 2; the page-local `casting`, `onTV`, and `airplayAvailable` flags.
-- Produces: nothing downstream. This is the last code task.
-
-- [ ] **Step 1: Add the time formatter**
-
-Insert above `present()`:
-
-```javascript
-  function clock(sec) {
-    if (!(sec > 0)) return "0:00";
-    var t = Math.floor(sec), h = Math.floor(t / 3600),
-        m = Math.floor((t % 3600) / 60), s = t % 60;
-    var mm = h > 0 && m < 10 ? "0" + m : String(m);
-    return (h > 0 ? h + ":" : "") + mm + ":" + (s < 10 ? "0" + s : s);
-  }
-```
-
-- [ ] **Step 2: Replace `present()` with the full state table**
-
-```javascript
   // One row of the spec's state table per branch. `act` is what the primary
   // button does when clicked: "start", "pick", or "stop".
   function present(s) {
@@ -575,20 +505,32 @@ Insert above `present()`:
   }
 ```
 
-- [ ] **Step 3: Dispatch the primary action**
+- [ ] **Step 6: Rewire the listeners and the button handlers**
 
-`primaryAct` was declared in Task 3, Step 3. Replace the two button handlers from Task 3 with:
+Two existing listeners reference removed elements. The media-error listener keeps its retry-once behavior exactly; only the reporting target changes.
 
 ```javascript
-  function teardownLocal() {
-    v.pause(); v.removeAttribute("src"); v.load();
-    loadedURL = null; retried = false; onTV = false;
-    v.muted = true; appliedSeq = 0; ended = false; initialSeekPending = false;
-    localErr = "";
-  }
-  function showPicker() {
-    if (v.webkitShowPlaybackTargetPicker) v.webkitShowPlaybackTargetPicker();
-  }
+  v.addEventListener("error", function () {
+    if (!loadedURL) return;                // src cleared by a stop, not a real failure
+    if (!retried) {                        // retry exactly once (docs/prototype.md)
+      retried = true;
+      v.src = loadedURL;
+      v.play().catch(function () {});
+    } else {
+      localErr = "Stream failed to load (media error " +
+        (v.error ? v.error.code : "?") + ").";
+    }
+  });
+  v.addEventListener("webkitplaybacktargetavailabilitychanged", function (ev) {
+    airplayAvailable = ev.availability === "available";
+  });
+```
+
+Leave `webkitcurrentplaybacktargetiswirelesschanged` and the `ended` listener as they are.
+
+Replace the old `pick.onclick` and `castBtn.onclick` assignments with:
+
+```javascript
   primary.onclick = function () {
     if (primaryAct === "pick") showPicker();
     else if (primaryAct === "stop") { teardownLocal(); iina.postMessage("stop", {}); }
@@ -602,35 +544,30 @@ Insert above `present()`:
   };
 ```
 
-Then replace the teardown block inside `render()` with a call to the shared helper, so the same eight assignments do not live in three places:
+- [ ] **Step 7: Confirm the polling block is untouched**
 
-```javascript
-    if (!casting && loadedURL) {
-      // main.js tore the cast down (helper died, file changed, TV ended):
-      // drop the stream locally too, or the element keeps AirPlaying a corpse.
-      teardownLocal();
-    }
-```
+The `setInterval` at the bottom of the file must still post `getState` every 500ms and still post `tvState` while casting. `render()` runs on each reply, which is what keeps the elapsed clock ticking — no extra timer is needed.
 
-- [ ] **Step 4: Keep the elapsed time ticking**
+- [ ] **Step 8: Verify no removed identifier survives**
 
-`render()` runs only when `main.js` posts state, which the page requests every 500ms — fast enough for a seconds display, so no extra timer is needed. Confirm the existing `setInterval` block at the bottom of the file still posts `getState` every 500ms and is otherwise unmodified.
+Run: `grep -n "statusEl\|errEl\|castBtn\|pick\b" plugin/sidebar.html`
+Expected: no output. Those four identifiers were removed with the old markup; any hit is a reference that will throw at runtime.
 
-- [ ] **Step 5: Run the test suite**
+- [ ] **Step 9: Run the test suite**
 
 Run: `make test`
-Expected: PASS — no tested code changed in this task; a failure means Task 2's changes regressed.
+Expected: PASS. This task changes no tested code, so a failure means Task 2 regressed.
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 10: Commit**
 
 ```bash
 git add plugin/sidebar.html
-git commit -m "feat: drive the sidebar card from the cast state table"
+git commit -m "feat: rebuild the sidebar as a glass card driven by the state table"
 ```
 
 ---
 
-### Task 5: Manual verification against the state table
+### Task 4: Manual verification against the state table
 
 **Files:**
 - Modify: none (fixes only, if the pass finds something)

--- a/docs/superpowers/plans/2026-08-30-sidebar-liquid-glass.md
+++ b/docs/superpowers/plans/2026-08-30-sidebar-liquid-glass.md
@@ -600,7 +600,7 @@ Confirm each, in System Settings → Appearance → Dark:
 
 - [ ] **Step 3: Repeat in light appearance**
 
-Switch to System Settings → Appearance → Light and walk the same six rows. The card must stay legible — dark text on the light sidebar material, no white-on-white.
+Switch to System Settings → Appearance → Light and walk the same rows. The card must stay legible — dark text on the light sidebar material, no white-on-white.
 
 - [ ] **Step 4: Check the narrow-sidebar case**
 

--- a/docs/superpowers/specs/2026-08-30-sidebar-liquid-glass-design.md
+++ b/docs/superpowers/specs/2026-08-30-sidebar-liquid-glass-design.md
@@ -75,10 +75,22 @@ screen. The accent stays present in the progress bar.
 | --- | --- | --- | --- | --- | --- | --- |
 | `idle` | none | Not casting | subtitle label | hidden | Start casting (accent) | none |
 | `starting` | amber | Packaging | subtitle label | `pct` | Send to TV (disabled) | Cancel |
-| `ready`/`packaged`, no devices | none | Ready to send | Waiting for AirPlay devices | full, neutral | Send to TV (disabled) | Stop casting |
-| `ready`/`packaged` | none | Ready to send | subtitle label | full, neutral | Send to TV (accent) | Stop casting |
+| `ready`, no devices | none | Ready to send | Waiting for AirPlay devices | `pct` | Send to TV (disabled) | Stop casting |
+| `ready` | none | Ready to send | subtitle label | `pct` | Send to TV (accent) | Stop casting |
+| `packaged`, no devices | none | Ready to send | Waiting for AirPlay devices | full, neutral | Send to TV (disabled) | Stop casting |
+| `packaged` | none | Ready to send | subtitle label | full, neutral | Send to TV (accent) | Stop casting |
 | on TV (`onTV` true) | green | Playing on TV | subtitle label | elapsed / duration | Stop casting (neutral) | Send to another TV |
 | `error` | red | Couldn't cast | `state.msg` | hidden | Try again (accent) | none |
+
+`ready` and `packaged` are two different moments, and the bar must not
+conflate them. The helper emits `ready` as soon as the first HLS segments
+exist (`helper/main.go`, polled every 200ms) and keeps emitting `progress`
+until the whole file is remuxed; `packaged` arrives only at the end. On a
+feature-length file that gap is minutes. So the bar tracks real packaging
+progress and the elapsed slot shows the live percentage until the phase is
+actually `packaged`. Readiness is carried by the "Ready to send" headline
+and the enabled button, which is what the user acts on — the stream is
+playable from `ready` onward.
 
 "On TV" is a page-local condition (`webkitCurrentPlaybackTargetIsWireless`),
 not a helper phase; it overrides the `ready`/`packaged` rows when true.

--- a/docs/superpowers/specs/2026-08-30-sidebar-liquid-glass-design.md
+++ b/docs/superpowers/specs/2026-08-30-sidebar-liquid-glass-design.md
@@ -91,9 +91,10 @@ and its event stream are untouched.
 ### `subtitleLabel(tracks)`
 
 A pure function beside `selectTracks`, taking a `selectTracks` result (or
-`null`) and returning `{ label, warn }`:
+`null`) and returning `{ label, warn }`. `label` is the finished display
+string, so the page does no string building:
 
-- `tracks.sub` present → `sub.lang` if set, else `sub.title` if set, else `"On"`
+- `tracks.sub` present → `"Subtitles: "` + `sub.lang`, else `sub.title`, else `"On"`
 - `tracks.subDropped` → `{ label: "Subtitles not supported", warn: true }`
 - `tracks` null (no castable tracks yet) → `{ label: "", warn: false }`
 - neither → `{ label: "No subtitles", warn: false }`

--- a/docs/superpowers/specs/2026-08-30-sidebar-liquid-glass-design.md
+++ b/docs/superpowers/specs/2026-08-30-sidebar-liquid-glass-design.md
@@ -1,0 +1,160 @@
+# Sidebar redesign: one glass card
+
+**Date:** 2026-08-30
+**Status:** approved by user (study A, light mode support, accent reserved for the affirmative action)
+
+## Problem
+
+The cast panel looks unfinished, and the reasons are specific:
+
+- **Two competing primaries.** `Send to TV` and `Stop casting` are both
+  full-width `#2f6fed` slabs, so nothing indicates which one is the action.
+- **Hardcoded web blue.** `#2f6fed` ignores the macOS accent, and the page
+  hardcodes dark text (`#e8e8ee`) on a transparent body, so it washes out
+  when IINA runs in light appearance.
+- **The status line truncates.** "Ready — click Send to TV." runs out of room
+  in a narrow sidebar; it is a label doing a button's job.
+- **The panel is all chrome.** Nothing shows elapsed time, and subtitle status
+  exists only as a one-shot OSD flash (`main.js:358`) that vanishes before it
+  can be read.
+
+## Constraint: the glass is painted, not sampled
+
+`backdrop-filter` inside a `WKWebView` blurs only the page's own compositing
+tree. Behind the page's transparent `body` sits IINA's native sidebar
+material, which WebKit cannot reach. Depth therefore comes from layered
+translucent fills, a specular top edge, and an inner hairline. The look holds;
+it does not shift with the video behind it. Do not spend effort trying to make
+real vibrancy work — it cannot.
+
+## Constraint: no AirPlay device name
+
+WebKit exposes only the boolean `webkitCurrentPlaybackTargetIsWireless`. There
+is no API for the selected target's name in a `WKWebView`. "Playing on TV" is
+the ceiling; "Playing on Bedroom" is not achievable.
+
+## Design: one glass card
+
+A single `.glass` container, 14px padding, 16px radius, **fluid width** — the
+IINA sidebar is user-resizable, so nothing is pinned to a fixed pixel width.
+
+Top to bottom:
+
+1. Header row — AirPlay glyph, `AIRPLAY` label, state dot
+2. Headline plus a secondary sub line
+3. Progress track, with an elapsed / duration row beneath it
+4. Action stack — one primary, one quiet secondary
+
+Every text line takes `text-overflow: ellipsis`. The times row uses
+`font-variant-numeric: tabular-nums` so digits do not jitter as they tick.
+
+### Tokens
+
+Six tokens, defined for both appearances, switched on `prefers-color-scheme`
+with the light palette on bare `:root`.
+
+| Token | Dark | Light |
+| --- | --- | --- |
+| `--glass-fill` | white 13% → 3.5% gradient | black 6% → 2% |
+| `--glass-edge` | white 10% | black 8% |
+| `--glass-spec` | white 22% inset top | white 70% inset top |
+| `--ink` / `--ink-2` | `#F2F3F5` / white 58% | `#1C1C1E` / black 55% |
+| `--accent` | `#0A84FF` | `#007AFF` |
+| `--warn` | `#F0C169` | `#8A5B06` |
+
+### Accent discipline
+
+**Accent is reserved for the affirmative action** — `Start casting`,
+`Send to TV`, `Try again`. While casting to a TV, `Stop casting` is a neutral
+glass button, not a blue one: a teardown should not be the loudest thing on
+screen. The accent stays present in the progress bar.
+
+### State to UI
+
+| Phase | Dot | Headline | Sub | Bar | Primary | Secondary |
+| --- | --- | --- | --- | --- | --- | --- |
+| `idle` | none | Not casting | subtitle label | hidden | Start casting (accent) | none |
+| `starting` | amber | Packaging | subtitle label | `pct` | Send to TV (disabled) | Cancel |
+| `ready`/`packaged`, no devices | none | Ready to send | Waiting for AirPlay devices | full, neutral | Send to TV (disabled) | Stop casting |
+| `ready`/`packaged` | none | Ready to send | subtitle label | full, neutral | Send to TV (accent) | Stop casting |
+| on TV (`onTV` true) | green | Playing on TV | subtitle label | elapsed / duration | Stop casting (neutral) | Send to another TV |
+| `error` | red | Couldn't cast | `state.msg` | hidden | Try again (accent) | none |
+
+"On TV" is a page-local condition (`webkitCurrentPlaybackTargetIsWireless`),
+not a helper phase; it overrides the `ready`/`packaged` rows when true.
+
+## Plumbing
+
+Two changes in `plugin/main.js`. **No helper protocol change** — the Go helper
+and its event stream are untouched.
+
+### `subtitleLabel(tracks)`
+
+A pure function beside `selectTracks`, taking a `selectTracks` result (or
+`null`) and returning `{ label, warn }`:
+
+- `tracks.sub` present → `sub.lang` if set, else `sub.title` if set, else `"On"`
+- `tracks.subDropped` → `{ label: "Subtitles not supported", warn: true }`
+- `tracks` null (no castable tracks yet) → `{ label: "", warn: false }`
+- neither → `{ label: "No subtitles", warn: false }`
+
+Unit-testable the way `selectTracks` and the `mirrorOn*` functions already are.
+
+### `stateForPage()` gains two derived fields
+
+`duration` and `subs` are **computed live in `stateForPage()`**, not stored on
+`state`:
+
+```js
+duration: mpv.getNumber("duration") || 0,
+subs: subtitleLabel(selectTracks(mpv.getNative("track-list") || [])),
+```
+
+This is safe: all three `stateForPage()` call sites (`main.js:444`, `451`,
+`455`) are inside `sidebar.onMessage` handlers, which run on the main thread.
+
+Deriving rather than storing matters for the `idle` row of the state table.
+`selectTracks` otherwise runs only at cast start (`main.js:350`), so a stored
+`subs` would be empty before the first cast — and the panel would have nothing
+to say about subtitles exactly when the user is deciding whether to cast.
+Deriving also keeps the label correct when the user switches subtitle track
+mid-session.
+
+Because neither field lands on `state`, the ten `state = { ... }` literals
+(`main.js:328`, `337`, `347`, `354`, `363`, `370`, `408`, `415`, `419`, `437`)
+are left alone. No factory, no refactor.
+
+The page reads elapsed from the `<video>` element it already owns — no field
+for it.
+
+The `subDropped` OSD at `main.js:358` stays — it is still right at the moment
+of the decision. The panel just stops being the only place that information
+briefly lived.
+
+## Edge cases
+
+- **Narrow sidebar** — text ellipsizes; action buttons stay full-width.
+- **Long subtitle titles** — truncate, with a `title` attribute for the tooltip.
+- **First-load media flake** — the existing retry-once behavior
+  (`docs/prototype.md`) is unchanged; failure surfaces only after the second
+  attempt.
+- **`prefers-reduced-motion`** — drops the progress bar transition.
+- **Sidebar threading** — unchanged. The page continues to poll `getState`;
+  nothing here calls `sidebar.*` from an `exec` callback.
+
+## Testing
+
+- `subtitleLabel` gets unit tests in `plugin/tests/main.test.mjs`, alongside
+  the existing pure-function tests: a text track with `lang`, one with only
+  `title`, one with neither, a `subDropped` result, and `null`.
+- The render path stays manual — it is DOM in a webview with no harness, as
+  today. Verify by driving all six rows of the state table against a real cast,
+  in both light and dark appearance.
+
+## Out of scope
+
+- File title in the panel (considered, not wanted).
+- Packaging detail beyond a percentage — would require new helper event fields.
+- Subtitle *picking* from the sidebar. The panel reports subtitle status only.
+  The tile grammar that would make a picker natural was study B, which was not
+  chosen.

--- a/docs/superpowers/specs/2026-08-30-sidebar-liquid-glass-design.md
+++ b/docs/superpowers/specs/2026-08-30-sidebar-liquid-glass-design.md
@@ -161,7 +161,7 @@ briefly lived.
   the existing pure-function tests: a text track with `lang`, one with only
   `title`, one with neither, a `subDropped` result, and `null`.
 - The render path stays manual — it is DOM in a webview with no harness, as
-  today. Verify by driving all six rows of the state table against a real cast,
+  today. Verify by driving every row of the state table against a real cast,
   in both light and dark appearance.
 
 ## Out of scope

--- a/plugin/main.js
+++ b/plugin/main.js
@@ -233,8 +233,16 @@ if (typeof iina !== "undefined") {
   // Every post to the page goes through this so the page always sees the live
   // sync block alongside the pipeline state.
   function stateForPage() {
+    // duration and subs are derived here, not stored on `state`: selectTracks
+    // otherwise runs only at cast start, so a stored label would be empty
+    // before the first cast — exactly when the user is deciding whether to
+    // cast — and would go stale if the subtitle track changed mid-session.
+    // Safe to read mpv here: every caller is a sidebar.onMessage handler,
+    // which IINA runs on the main thread.
     return {
       phase: state.phase, url: state.url, pct: state.pct, msg: state.msg,
+      duration: mpv.getNumber("duration") || 0,
+      subs: subtitleLabel(selectTracks(mpv.getNative("track-list") || [])),
       sync: mirror === null ? null : {
         seq: mirror.seq, paused: mirror.paused,
         seekTo: mirror.seekTo, startPos: mirror.startPos,

--- a/plugin/main.js
+++ b/plugin/main.js
@@ -44,6 +44,17 @@ function selectTracks(trackList) {
   return r;
 }
 
+// selectTracks already decided what happens to subtitles; this just names the
+// decision for the sidebar. Before the redesign that answer existed only as a
+// one-shot OSD flash, which vanished before it could be read.
+function subtitleLabel(tracks) {
+  if (!tracks) return { label: "", warn: false };
+  if (tracks.subDropped) return { label: "Subtitles not supported", warn: true };
+  if (!tracks.sub) return { label: "No subtitles", warn: false };
+  return { label: "Subtitles: " + (tracks.sub.lang || tracks.sub.title || "On"),
+           warn: false };
+}
+
 function parseHelperEvents(buffer, chunk) {
   var data = buffer + chunk;
   var lines = data.split("\n");
@@ -183,6 +194,7 @@ function mirrorOnTvState(m, tvState, mpvPos, mpvPaused, now) {
 if (typeof module !== "undefined") {
   module.exports = {
     selectTracks: selectTracks,
+    subtitleLabel: subtitleLabel,
     parseHelperEvents: parseHelperEvents,
     pluginsDirFromDataDir: pluginsDirFromDataDir,
     isValidPid: isValidPid,

--- a/plugin/sidebar.html
+++ b/plugin/sidebar.html
@@ -2,36 +2,142 @@
 <meta charset="utf-8">
 <title>AirPlay</title>
 <style>
-  html, body { margin: 0; background: transparent; color: #e8e8ee;
-    font: 13px/1.5 -apple-system, BlinkMacSystemFont, sans-serif; }
+  :root {
+    --glass-fill-top: rgba(0, 0, 0, 0.06);
+    --glass-fill-bot: rgba(0, 0, 0, 0.02);
+    --glass-edge: rgba(0, 0, 0, 0.08);
+    --glass-spec: rgba(255, 255, 255, 0.70);
+    --track: rgba(0, 0, 0, 0.10);
+    --neutral-btn: rgba(0, 0, 0, 0.06);
+    --ink: #1C1C1E;
+    --ink-2: rgba(0, 0, 0, 0.55);
+    --accent: #007AFF;
+    --accent-hi: #40A0FF;
+    --warn: #8A5B06;
+    --shade: rgba(255, 255, 255, 0.45);
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --glass-fill-top: rgba(255, 255, 255, 0.13);
+      --glass-fill-bot: rgba(255, 255, 255, 0.035);
+      --glass-edge: rgba(255, 255, 255, 0.10);
+      --glass-spec: rgba(255, 255, 255, 0.22);
+      --track: rgba(255, 255, 255, 0.13);
+      --neutral-btn: rgba(255, 255, 255, 0.09);
+      --ink: #F2F3F5;
+      --ink-2: rgba(255, 255, 255, 0.58);
+      --accent: #0A84FF;
+      --accent-hi: #3D9BFF;
+      --warn: #F0C169;
+      --shade: rgba(255, 255, 255, 0.90);
+    }
+  }
+
+  html, body { margin: 0; background: transparent; color: var(--ink);
+    font: 13px/1.45 -apple-system, BlinkMacSystemFont, sans-serif;
+    -webkit-font-smoothing: antialiased; }
   video { width: 1px; height: 1px; opacity: 0.01; position: absolute; }
-  #wrap { padding: 14px; }
-  button { display: block; width: 100%; padding: 10px; margin: 8px 0;
-    font: inherit; font-weight: 600; border-radius: 8px; border: none;
-    background: #2f6fed; color: white; cursor: pointer; }
-  button:disabled { background: #444; color: #999; }
-  #bar { height: 4px; background: #333; border-radius: 2px; margin: 10px 0; }
-  #fill { height: 100%; width: 0; background: #2f6fed; border-radius: 2px; }
-  #status { min-height: 2.6em; }
-  #err { color: #e8b84a; white-space: pre-wrap; font-size: 11px; }
+  #wrap { padding: 12px; }
+
+  #card {
+    display: flex; flex-direction: column; gap: 12px;
+    padding: 14px; border-radius: 16px;
+    background: linear-gradient(180deg, var(--glass-fill-top), var(--glass-fill-bot));
+    -webkit-backdrop-filter: blur(22px) saturate(180%);
+    backdrop-filter: blur(22px) saturate(180%);
+    border: 1px solid var(--glass-edge);
+    box-shadow: inset 0 1px 0 var(--glass-spec), 0 8px 22px rgba(0, 0, 0, 0.16);
+  }
+
+  .row { display: flex; align-items: center; gap: 8px; }
+  .spread { justify-content: space-between; }
+  .grow { min-width: 0; }
+
+  #head { color: var(--ink-2); }
+  #head svg { width: 16px; height: 16px; flex: none; }
+  #cap { font-size: 10px; font-weight: 600; letter-spacing: 0.09em;
+    text-transform: uppercase; }
+
+  #dot { width: 6px; height: 6px; border-radius: 50%; flex: none;
+    background: transparent; }
+  #dot.busy { background: #E0A93C; box-shadow: 0 0 7px rgba(224, 169, 60, 0.75); }
+  #dot.live { background: #30C24E; box-shadow: 0 0 7px rgba(48, 194, 78, 0.75); }
+  #dot.bad  { background: #E0523C; box-shadow: 0 0 7px rgba(224, 82, 60, 0.75); }
+
+  #headline { margin: 0; font-size: 15px; font-weight: 590;
+    letter-spacing: -0.01em; }
+  #sub { margin: 0; font-size: 12px; color: var(--ink-2); }
+  #sub.warn { color: var(--warn); }
+  #headline, #sub { overflow: hidden; text-overflow: ellipsis;
+    white-space: nowrap; }
+
+  #meter { display: flex; flex-direction: column; gap: 6px; }
+  #bar { height: 5px; border-radius: 3px; background: var(--track);
+    overflow: hidden; }
+  #fill { height: 100%; width: 0; border-radius: 3px;
+    background: linear-gradient(180deg, var(--accent-hi), var(--accent));
+    transition: width 0.4s cubic-bezier(0.32, 0.72, 0, 1); }
+  #fill.done { background: var(--shade); }
+  #times { font-size: 11.5px; color: var(--ink-2);
+    font-variant-numeric: tabular-nums; }
+
+  #actions { display: flex; flex-direction: column; gap: 6px; }
+  button { display: block; width: 100%; padding: 9px 12px; border: none;
+    border-radius: 11px; font: inherit; font-size: 13px; font-weight: 590;
+    cursor: pointer; color: var(--ink); background: var(--neutral-btn);
+    box-shadow: inset 0 1px 0 var(--glass-spec); }
+  button.accent { color: #fff;
+    background: linear-gradient(180deg, var(--accent-hi), var(--accent));
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35),
+                0 4px 12px rgba(10, 111, 232, 0.30); }
+  button.quiet { background: transparent; box-shadow: none;
+    color: var(--ink-2); font-weight: 500; font-size: 12.5px; padding: 5px; }
+  button:disabled { color: var(--ink-2); background: var(--neutral-btn);
+    box-shadow: none; cursor: default; opacity: 0.6; }
+  button:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+  .hide { display: none; }
+
+  @media (prefers-reduced-motion: reduce) { #fill { transition: none; } }
 </style>
 
 <div id="wrap">
-  <p id="status">Preparing…</p>
-  <div id="bar"><div id="fill"></div></div>
-  <button id="pick" disabled>Send to TV</button>
-  <button id="cast">Stop casting</button>
-  <p id="err"></p>
+  <div id="card">
+    <div class="row spread" id="head">
+      <div class="row" style="gap:6px">
+        <svg viewBox="0 0 24 24" fill="none" aria-hidden="true"><rect x="2.4" y="3.4" width="19.2" height="13" rx="2.6" stroke="currentColor" stroke-width="1.6" opacity="0.75"/><path d="M12 14.4 17 21H7z" fill="currentColor"/></svg>
+        <span id="cap">AirPlay</span>
+      </div>
+      <span id="dot"></span>
+    </div>
+    <div class="grow">
+      <p id="headline">Preparing…</p>
+      <p id="sub"></p>
+    </div>
+    <div id="meter">
+      <div id="bar"><div id="fill"></div></div>
+      <div class="row spread" id="times">
+        <span id="elapsed"></span><span id="total"></span>
+      </div>
+    </div>
+    <div id="actions">
+      <button id="primary" type="button"></button>
+      <button id="secondary" type="button" class="quiet"></button>
+    </div>
+  </div>
 </div>
 <video id="v" autoplay muted playsinline x-webkit-airplay="allow"></video>
 
 <script>
   var v = document.getElementById("v");
-  var pick = document.getElementById("pick");
-  var castBtn = document.getElementById("cast");
-  var statusEl = document.getElementById("status");
-  var errEl = document.getElementById("err");
+  var dot = document.getElementById("dot");
+  var headline = document.getElementById("headline");
+  var subEl = document.getElementById("sub");
+  var meter = document.getElementById("meter");
   var fill = document.getElementById("fill");
+  var elapsedEl = document.getElementById("elapsed");
+  var totalEl = document.getElementById("total");
+  var primary = document.getElementById("primary");
+  var secondary = document.getElementById("secondary");
   var loadedURL = null;
   var retried = false;      // known WebKit flake: first load may fail once
   var airplayAvailable = false;
@@ -40,6 +146,8 @@
   var appliedSeq = 0;
   var initialSeekPending = false;
   var ended = false;
+  var localErr = "";        // page-side media failure, distinct from state.msg
+  var primaryAct = "start"; // what #primary does: "start" | "pick" | "stop"
 
   function applySync(sync) {
     if (!sync || !loadedURL) return;
@@ -68,30 +176,32 @@
     }
   }
 
+  function teardownLocal() {
+    v.pause(); v.removeAttribute("src"); v.load();
+    loadedURL = null; retried = false; onTV = false;
+    v.muted = true; appliedSeq = 0; ended = false; initialSeekPending = false;
+    localErr = "";
+  }
+  function showPicker() {
+    if (v.webkitShowPlaybackTargetPicker) v.webkitShowPlaybackTargetPicker();
+  }
+  function clock(sec) {
+    if (!(sec > 0)) return "0:00";
+    var t = Math.floor(sec), h = Math.floor(t / 3600),
+        m = Math.floor((t % 3600) / 60), s = t % 60;
+    var mm = h > 0 && m < 10 ? "0" + m : String(m);
+    return (h > 0 ? h + ":" : "") + mm + ":" + (s < 10 ? "0" + s : s);
+  }
+
   function render(s) {
     casting = s.phase === "starting" || s.phase === "ready" || s.phase === "packaged";
-    castBtn.textContent = casting ? "Stop casting" : "Start casting";
-    // Nothing to hand to a TV when no stream is loaded, and the availability
-    // event can lag a teardown — so gate the picker on the cast, not just on it.
-    pick.disabled = !airplayAvailable || !casting;
-    fill.style.width = (s.pct || 0) + "%";
     if (!casting && loadedURL) {
       // main.js tore the cast down (helper died, file changed, TV ended):
       // drop the stream locally too, or the element keeps AirPlaying a corpse.
-      v.pause(); v.removeAttribute("src"); v.load();
-      loadedURL = null; retried = false; onTV = false;
-      v.muted = true; appliedSeq = 0; ended = false; initialSeekPending = false;
+      teardownLocal();
     }
     applySync(s.sync);
-    if (s.phase === "error") { statusEl.textContent = "Failed."; errEl.textContent = s.msg || ""; return; }
-    errEl.textContent = "";
-    if (onTV) { statusEl.textContent = "Playing on TV."; return; }
-    if (s.phase === "idle") statusEl.textContent = "Not casting.";
-    else if (s.phase === "starting") statusEl.textContent = "Packaging…";
-    else if (s.phase === "ready" || s.phase === "packaged") {
-      statusEl.textContent = airplayAvailable ? "Ready — click Send to TV."
-                                              : "Ready — waiting for AirPlay devices…";
-    }
+    present(s);
     if ((s.phase === "ready" || s.phase === "packaged") && s.url && s.url !== loadedURL) {
       loadedURL = s.url;
       retried = false;
@@ -104,6 +214,68 @@
     }
   }
 
+  // One row of the spec's state table per branch. `act` is what the primary
+  // button does when clicked: "start", "pick", or "stop".
+  function present(s) {
+    var subs = s.subs || { label: "", warn: false };
+    var r;
+    if (s.phase === "error" || localErr) {
+      // A page-side media failure is still a failed cast from the user's side,
+      // so it takes the same row. state.msg wins when both are set: main.js
+      // knows why the pipeline died, the <video> element only knows it choked.
+      r = { dot: "bad", headline: "Couldn't cast", sub: s.msg || localErr,
+            warn: true, meter: false, pct: 0, done: false,
+            primary: "Try again", act: "start", accent: true, off: false,
+            secondary: casting ? "Stop casting" : null };
+    } else if (!casting) {
+      r = { dot: "", headline: "Not casting", sub: subs.label,
+            warn: subs.warn, meter: false, pct: 0, done: false,
+            primary: "Start casting", act: "start", accent: true, off: false,
+            secondary: null };
+    } else if (s.phase === "starting") {
+      r = { dot: "busy", headline: "Packaging", sub: subs.label,
+            warn: subs.warn, meter: true, pct: s.pct || 0, done: false,
+            primary: "Send to TV", act: "pick", accent: true, off: true,
+            secondary: "Cancel" };
+    } else if (onTV) {
+      var pos = v.currentTime || 0;
+      r = { dot: "live", headline: "Playing on TV", sub: subs.label,
+            warn: subs.warn, meter: true, done: false,
+            pct: s.duration > 0 ? (pos / s.duration) * 100 : 0,
+            primary: "Stop casting", act: "stop", accent: false, off: false,
+            secondary: "Send to another TV" };
+    } else {
+      r = { dot: "", headline: "Ready to send",
+            sub: airplayAvailable ? subs.label : "Waiting for AirPlay devices…",
+            warn: airplayAvailable && subs.warn,
+            meter: true, pct: 100, done: true,
+            primary: "Send to TV", act: "pick", accent: true,
+            off: !airplayAvailable, secondary: "Stop casting" };
+    }
+
+    dot.className = r.dot;
+    headline.textContent = r.headline;
+    subEl.textContent = r.sub;
+    subEl.title = r.sub;                 // the full string, when it ellipsizes
+    subEl.className = r.warn ? "warn" : "";
+
+    meter.className = r.meter ? "" : "hide";
+    fill.style.width = Math.max(0, Math.min(100, r.pct)) + "%";
+    fill.className = r.done ? "done" : "";
+    elapsedEl.textContent = onTV ? clock(v.currentTime || 0)
+                          : s.phase === "starting" ? Math.round(s.pct || 0) + "%"
+                          : "Packaged";
+    totalEl.textContent = s.duration > 0 ? clock(s.duration) : "";
+
+    primary.textContent = r.primary;
+    primary.disabled = r.off;
+    primary.className = r.accent && !r.off ? "accent" : "";
+    primaryAct = r.act;
+
+    secondary.textContent = r.secondary || "";
+    secondary.className = r.secondary ? "quiet" : "quiet hide";
+  }
+
   v.addEventListener("error", function () {
     if (!loadedURL) return;                // src cleared by a stop, not a real failure
     if (!retried) {                        // retry exactly once (docs/prototype.md)
@@ -111,33 +283,28 @@
       v.src = loadedURL;
       v.play().catch(function () {});
     } else {
-      errEl.textContent = "Stream failed to load (media error " +
+      localErr = "Stream failed to load (media error " +
         (v.error ? v.error.code : "?") + ").";
     }
   });
   v.addEventListener("webkitplaybacktargetavailabilitychanged", function (ev) {
     airplayAvailable = ev.availability === "available";
-    pick.disabled = !airplayAvailable || !casting;
   });
   v.addEventListener("webkitcurrentplaybacktargetiswirelesschanged", function () {
     onTV = !!v.webkitCurrentPlaybackTargetIsWireless;
     v.muted = !onTV;   // silent on the Mac, audible on the TV
   });
   v.addEventListener("ended", function () { ended = true; });
-  pick.onclick = function () {
-    if (v.webkitShowPlaybackTargetPicker) v.webkitShowPlaybackTargetPicker();
+  primary.onclick = function () {
+    if (primaryAct === "pick") showPicker();
+    else if (primaryAct === "stop") { teardownLocal(); iina.postMessage("stop", {}); }
+    else { localErr = ""; iina.postMessage("start", {}); }
   };
-  castBtn.onclick = function () {
-    if (casting) {
-      v.pause(); v.removeAttribute("src"); v.load();
-      loadedURL = null; retried = false; onTV = false;
-      v.muted = true; appliedSeq = 0; ended = false; initialSeekPending = false;
-      iina.postMessage("stop", {});
-    } else {
-      errEl.textContent = "";
-      statusEl.textContent = "Packaging…";
-      iina.postMessage("start", {});
-    }
+  secondary.onclick = function () {
+    // "Send to another TV" while playing; "Cancel"/"Stop casting" otherwise.
+    if (onTV) { showPicker(); return; }
+    teardownLocal();
+    iina.postMessage("stop", {});
   };
   iina.onMessage("state", render);
   setInterval(function () {

--- a/plugin/sidebar.html
+++ b/plugin/sidebar.html
@@ -96,6 +96,7 @@
     box-shadow: none; cursor: default; opacity: 0.6; }
   button:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
   .hide { display: none; }
+  #meter.hide { display: none; }
 
   @media (prefers-reduced-motion: reduce) { #fill { transition: none; } }
 </style>
@@ -298,7 +299,7 @@
   primary.onclick = function () {
     if (primaryAct === "pick") showPicker();
     else if (primaryAct === "stop") { teardownLocal(); iina.postMessage("stop", {}); }
-    else { localErr = ""; iina.postMessage("start", {}); }
+    else { teardownLocal(); iina.postMessage("start", {}); }
   };
   secondary.onclick = function () {
     // "Send to another TV" while playing; "Cancel"/"Stop casting" otherwise.

--- a/plugin/sidebar.html
+++ b/plugin/sidebar.html
@@ -14,7 +14,7 @@
     --accent: #007AFF;
     --accent-hi: #40A0FF;
     --warn: #8A5B06;
-    --shade: rgba(255, 255, 255, 0.45);
+    --shade: rgba(0, 0, 0, 0.28);
   }
   @media (prefers-color-scheme: dark) {
     :root {
@@ -114,15 +114,15 @@
       <p id="headline">Preparing…</p>
       <p id="sub"></p>
     </div>
-    <div id="meter">
+    <div id="meter" class="hide">
       <div id="bar"><div id="fill"></div></div>
       <div class="row spread" id="times">
         <span id="elapsed"></span><span id="total"></span>
       </div>
     </div>
     <div id="actions">
-      <button id="primary" type="button"></button>
-      <button id="secondary" type="button" class="quiet"></button>
+      <button id="primary" type="button" class="hide"></button>
+      <button id="secondary" type="button" class="quiet hide"></button>
     </div>
   </div>
 </div>
@@ -149,6 +149,7 @@
   var ended = false;
   var localErr = "";        // page-side media failure, distinct from state.msg
   var primaryAct = "start"; // what #primary does: "start" | "pick" | "stop"
+  var secondaryAct = null;  // what #secondary does: null | "pick" | "stop"
 
   function applySync(sync) {
     if (!sync || !loadedURL) return;
@@ -181,7 +182,6 @@
     v.pause(); v.removeAttribute("src"); v.load();
     loadedURL = null; retried = false; onTV = false;
     v.muted = true; appliedSeq = 0; ended = false; initialSeekPending = false;
-    localErr = "";
   }
   function showPicker() {
     if (v.webkitShowPlaybackTargetPicker) v.webkitShowPlaybackTargetPicker();
@@ -227,31 +227,33 @@
       r = { dot: "bad", headline: "Couldn't cast", sub: s.msg || localErr,
             warn: true, meter: false, pct: 0, done: false,
             primary: "Try again", act: "start", accent: true, off: false,
-            secondary: casting ? "Stop casting" : null };
+            secondary: casting ? "Stop casting" : null,
+            sact: casting ? "stop" : null };
     } else if (!casting) {
       r = { dot: "", headline: "Not casting", sub: subs.label,
             warn: subs.warn, meter: false, pct: 0, done: false,
             primary: "Start casting", act: "start", accent: true, off: false,
-            secondary: null };
+            secondary: null, sact: null };
     } else if (s.phase === "starting") {
       r = { dot: "busy", headline: "Packaging", sub: subs.label,
             warn: subs.warn, meter: true, pct: s.pct || 0, done: false,
             primary: "Send to TV", act: "pick", accent: true, off: true,
-            secondary: "Cancel" };
+            secondary: "Cancel", sact: "stop" };
     } else if (onTV) {
       var pos = v.currentTime || 0;
       r = { dot: "live", headline: "Playing on TV", sub: subs.label,
             warn: subs.warn, meter: true, done: false,
             pct: s.duration > 0 ? (pos / s.duration) * 100 : 0,
             primary: "Stop casting", act: "stop", accent: false, off: false,
-            secondary: "Send to another TV" };
+            secondary: "Send to another TV", sact: "pick" };
     } else {
+      var packaged = s.phase === "packaged";
       r = { dot: "", headline: "Ready to send",
             sub: airplayAvailable ? subs.label : "Waiting for AirPlay devices…",
             warn: airplayAvailable && subs.warn,
-            meter: true, pct: 100, done: true,
+            meter: true, pct: packaged ? 100 : (s.pct || 0), done: packaged,
             primary: "Send to TV", act: "pick", accent: true,
-            off: !airplayAvailable, secondary: "Stop casting" };
+            off: !airplayAvailable, secondary: "Stop casting", sact: "stop" };
     }
 
     dot.className = r.dot;
@@ -264,8 +266,8 @@
     fill.style.width = Math.max(0, Math.min(100, r.pct)) + "%";
     fill.className = r.done ? "done" : "";
     elapsedEl.textContent = onTV ? clock(v.currentTime || 0)
-                          : s.phase === "starting" ? Math.round(s.pct || 0) + "%"
-                          : "Packaged";
+                          : s.phase === "packaged" ? "Packaged"
+                          : Math.round(s.pct || 0) + "%";
     totalEl.textContent = s.duration > 0 ? clock(s.duration) : "";
 
     primary.textContent = r.primary;
@@ -275,6 +277,7 @@
 
     secondary.textContent = r.secondary || "";
     secondary.className = r.secondary ? "quiet" : "quiet hide";
+    secondaryAct = r.sact;
   }
 
   v.addEventListener("error", function () {
@@ -298,14 +301,17 @@
   v.addEventListener("ended", function () { ended = true; });
   primary.onclick = function () {
     if (primaryAct === "pick") showPicker();
-    else if (primaryAct === "stop") { teardownLocal(); iina.postMessage("stop", {}); }
-    else { teardownLocal(); iina.postMessage("start", {}); }
+    else if (primaryAct === "stop") {
+      localErr = ""; teardownLocal(); iina.postMessage("stop", {});
+    } else {
+      localErr = ""; teardownLocal(); iina.postMessage("start", {});
+    }
   };
   secondary.onclick = function () {
-    // "Send to another TV" while playing; "Cancel"/"Stop casting" otherwise.
-    if (onTV) { showPicker(); return; }
-    teardownLocal();
-    iina.postMessage("stop", {});
+    if (secondaryAct === "pick") showPicker();
+    else if (secondaryAct === "stop") {
+      localErr = ""; teardownLocal(); iina.postMessage("stop", {});
+    }
   };
   iina.onMessage("state", render);
   setInterval(function () {

--- a/plugin/tests/main.test.mjs
+++ b/plugin/tests/main.test.mjs
@@ -2,7 +2,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { createRequire } from "node:module";
 const require = createRequire(import.meta.url);
-const { selectTracks, parseHelperEvents, pluginsDirFromDataDir, isValidPid, hasURLScheme, normalizeSource } = require("../main.js");
+const { selectTracks, subtitleLabel, parseHelperEvents, pluginsDirFromDataDir, isValidPid, hasURLScheme, normalizeSource } = require("../main.js");
 
 const mpvTracks = [
   { type: "video", id: 1, selected: true, codec: "hevc", "ff-index": 0 },
@@ -162,4 +162,51 @@ test("isValidPid accepts positive finite numbers only", () => {
   assert.equal(isValidPid(undefined), false);
   assert.equal(isValidPid(null), false);
   assert.equal(isValidPid("1234"), false);
+});
+
+test("subtitleLabel names the track by language", () => {
+  const tracks = selectTracks([
+    { type: "video", selected: true, codec: "hevc", "ff-index": 0 },
+    { type: "audio", selected: true, codec: "aac", "ff-index": 1 },
+    { type: "sub", selected: true, codec: "subrip", "ff-index": 2, lang: "eng" },
+  ]);
+  assert.deepEqual(subtitleLabel(tracks), { label: "Subtitles: eng", warn: false });
+});
+
+test("subtitleLabel falls back to the track title, then to On", () => {
+  const base = [
+    { type: "video", selected: true, codec: "hevc", "ff-index": 0 },
+    { type: "audio", selected: true, codec: "aac", "ff-index": 1 },
+  ];
+  const titled = selectTracks(base.concat([
+    { type: "sub", selected: true, codec: "subrip", "ff-index": 2, title: "Forced" },
+  ]));
+  assert.equal(subtitleLabel(titled).label, "Subtitles: Forced");
+
+  const bare = selectTracks(base.concat([
+    { type: "sub", selected: true, codec: "subrip", "ff-index": 2 },
+  ]));
+  assert.equal(subtitleLabel(bare).label, "Subtitles: On");
+});
+
+test("subtitleLabel warns when the subtitle track was dropped", () => {
+  const tracks = selectTracks([
+    { type: "video", selected: true, codec: "hevc", "ff-index": 0 },
+    { type: "audio", selected: true, codec: "aac", "ff-index": 1 },
+    { type: "sub", selected: true, codec: "hdmv_pgs_subtitle", "ff-index": 2 },
+  ]);
+  assert.deepEqual(subtitleLabel(tracks),
+    { label: "Subtitles not supported", warn: true });
+});
+
+test("subtitleLabel reports no subtitles when none is selected", () => {
+  const tracks = selectTracks([
+    { type: "video", selected: true, codec: "hevc", "ff-index": 0 },
+    { type: "audio", selected: true, codec: "aac", "ff-index": 1 },
+  ]);
+  assert.deepEqual(subtitleLabel(tracks), { label: "No subtitles", warn: false });
+});
+
+test("subtitleLabel is empty when there are no castable tracks", () => {
+  assert.deepEqual(subtitleLabel(null), { label: "", warn: false });
 });

--- a/plugin/tests/runtime.test.mjs
+++ b/plugin/tests/runtime.test.mjs
@@ -359,3 +359,32 @@ test("restarting a cast after a helper-initiated teardown does not corrupt the s
   p.send("stop", {});
   assert.equal(p.flags.mute, false, "savedMute must come from the user's real pre-cast value");
 });
+
+test("state carries duration and a subtitle label", () => {
+  const p = loadPlugin();
+  p.clickMenu();
+  p.send("getState", {}); // simulate the page's poll so a "state" message is posted
+  const s = p.state();
+  assert.equal(s.duration, 120);
+  assert.deepEqual(s.subs, { label: "No subtitles", warn: false });
+});
+
+test("state reports the selected subtitle track", () => {
+  const p = loadPlugin({ tracks: [
+    { type: "video", selected: true, codec: "hevc", "ff-index": 0 },
+    { type: "audio", selected: true, codec: "aac", "ff-index": 1, "demux-channel-count": 2 },
+    { type: "sub", selected: true, codec: "subrip", "ff-index": 2, lang: "eng" },
+  ] });
+  p.clickMenu();
+  p.send("getState", {}); // simulate the page's poll so a "state" message is posted
+  assert.equal(p.state().subs.label, "Subtitles: eng");
+});
+
+test("subtitle label is available before any cast starts", () => {
+  const p = loadPlugin();
+  p.clickMenu();
+  p.send("stop");
+  const s = p.state();
+  assert.equal(s.phase, "idle");
+  assert.equal(s.subs.label, "No subtitles");
+});


### PR DESCRIPTION
The cast panel was two identical blue slabs and a status sentence that ran
out of room. This replaces it with a single translucent card that has one
primary action, and surfaces two things the old panel never showed.

## What changed

**One primary, and it follows the phase.** `Send to TV` when a stream is
ready; `Stop casting` once the TV has it. Accent is reserved for the
affirmative action — `Start casting`, `Send to TV`, `Try again` — so a
teardown is never the loudest thing on screen.

**Both appearances.** The page hardcoded dark text on a transparent body,
which washed out whenever IINA ran in light appearance. Six tokens now
switch on `prefers-color-scheme`.

**Elapsed time and subtitle status are visible.** Subtitle status
previously existed only as a one-shot OSD flash that vanished before it
could be read; it is now a persistent line, and an unsupported track says
so instead of silently disappearing.

The glass is painted, not sampled: `backdrop-filter` in a `WKWebView`
blurs only the page's own compositing tree, and IINA's native sidebar
material behind the transparent body is out of WebKit's reach. Depth comes
from layered fills, a specular top edge, and an inner hairline.

## Plumbing

`stateForPage()` gains `duration` and `subs`, both **derived per call**
rather than stored on `state`. `selectTracks` otherwise runs only at cast
start, so a stored label would be empty before the first cast — exactly
when the user is deciding whether to cast — and would go stale if the
subtitle track changed mid-session. Safe to read mpv there: all three call
sites are `sidebar.onMessage` handlers, which run on the main thread.

No helper protocol change. The muted-mirror sync logic is untouched.

## Notable fixes found in review

- **`.hide` never hid the meter.** `#meter` (id) beat `.hide` (class), so
  the progress bar stayed on screen while idle, reading "Packaged" with a
  duration when nothing was casting.
- **"Try again" was a dead end.** `startCast()` returns early for
  `ready`/`packaged`, so the retry did nothing while clearing the error —
  leaving "Ready to send" over a `<video>` still in its error state.
- **The state table conflated `ready` and `packaged`.** The helper emits
  `ready` as soon as the first HLS segments exist and `packaged` only when
  the remux finishes; on a feature-length file that gap is minutes, during
  which the card claimed "Packaged" with a full bar. The bar now tracks
  real progress.

## Testing

83 tests pass. `subtitleLabel` has unit tests; `stateForPage`'s new fields
are covered in the runtime tests, including the case that pins the
derive-don't-store decision.

The render path has no automated harness — it only renders inside IINA —
so every row of the state table was driven through a stubbed browser
harness, and @ozykhan verified the real thing against a live Apple TV in
both appearances.

Design spec and plan are in `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)