### PR TITLE
docs: make the repo legible to an outside contributor

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,71 @@
+name: Bug report
+description: Something is broken — a cast that fails, a crash, a wrong result
+title: "[area] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Replace `[area]` in the title with the surface this touches:
+        `[plugin]`, `[helper]`, `[packaging]`, `[repo]` or `[docs]`.
+
+        Casting depends on the file, the Mac and the TV, so the details below
+        are what make a report actionable. If you're reporting something that
+        isn't a cast failure (a build break, a docs error), skip the fields
+        that don't apply.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What you did, what you expected, what you got instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: versions
+    attributes:
+      label: Versions
+      value: |
+        - macOS:
+        - Mac model:
+        - IINA:
+        - Plugin version (Info.json `version`, or "built from source at <commit>"):
+        - Installed via: IINA's plugin installer / local package / `make dev`
+    validations:
+      required: true
+
+  - type: textarea
+    id: device
+    attributes:
+      label: AirPlay device
+      description: Leave blank if the failure happens before any cast is attempted.
+      value: |
+        - Model (e.g. Apple TV 4K 3rd gen):
+        - tvOS version:
+
+  - type: textarea
+    id: media
+    attributes:
+      label: The file
+      description: >
+        `ffprobe -hide_banner <file>` output is ideal. Otherwise: container,
+        video codec, audio codec, and which subtitle track was selected.
+      render: text
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Plugin console log
+      description: >
+        IINA → Settings → Plugins → select the plugin → console. Copy the lines
+        from the failed attempt.
+      render: text
+
+  - type: checkboxes
+    id: local-network
+    attributes:
+      label: Checks
+      options:
+        - label: On macOS 15+, IINA has the Local Network permission granted.
+        - label: I installed through IINA's plugin installer, or built from source — not by downloading the `.iinaplgz` in a browser.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: How to build, test and contribute
+    url: https://github.com/ozykhan/iina-airplay/blob/master/CONTRIBUTING.md
+    about: Dev loop, test suite, branch workflow and the constraints that bite newcomers.
+  - name: Why this is a handoff and not a mirror
+    url: https://github.com/ozykhan/iina-airplay/blob/master/docs/feasibility.md
+    about: The platform limits behind the design, with sources. Read before proposing an architecture change.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,44 @@
+name: Feature request
+description: Propose a change or an addition
+title: "[area] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Replace `[area]` in the title with the surface this touches:
+        `[plugin]`, `[helper]`, `[packaging]`, `[repo]` or `[docs]`.
+
+        Before proposing an architecture change, please read
+        [`docs/feasibility.md`](https://github.com/ozykhan/iina-airplay/blob/master/docs/feasibility.md) — it
+        records which routes the platform closes off, and why this is a handoff
+        rather than a mirror.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: The problem
+      description: What doesn't work today, or what you can't do.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What you'd like instead
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Including anything you tried that didn't work.
+
+  - type: checkboxes
+    id: scope
+    attributes:
+      label: Scope check
+      options:
+        - label: This doesn't require native code in the plugin (the plugin API is JavaScript only).
+        - label: This doesn't make the common path re-encode where it could remux.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+<!--
+The PR title and body become the squashed commit on master. Write them as the
+changelog entry you'd want to read a year from now.
+-->
+
+## What and why
+
+<!-- What changes, and what problem it solves. -->
+
+Part of #
+
+## How it was tested
+
+<!--
+`make test` is the baseline. Say what else you exercised.
+
+Casting to a real Apple TV can't be automated — if you couldn't verify that
+last step, say so. It's an expected gap, not a problem; it just tells the
+maintainer what to check before merging.
+-->
+
+- [ ] `make test` passes locally
+- [ ] Cast end-to-end to a real AirPlay device — or: not verified (no device)
+
+## Checklist
+
+- [ ] Conventional-commit style title (`feat:`, `fix:`, `docs:`, …)
+- [ ] `plugin/Info.json` is not committed (it's a `make dev` symlink)
+- [ ] Docs updated if behaviour or the build changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,174 @@
+# Contributing
+
+Thanks for taking an interest. This is a small, opinionated repo: an IINA plugin
+(JavaScript), a Go helper that drives `ffmpeg`, and the packaging that turns the
+two into an `.iinaplgz` a stranger can install. Everything below is what you'd
+otherwise have to reverse-engineer.
+
+Start with [`README.md`](README.md) for what the plugin does and
+[`docs/feasibility.md`](docs/feasibility.md) for why it does it that way. If
+you're proposing an architecture change, read the feasibility doc *first* — most
+"why don't you just mirror the screen?" ideas are closed off by the platform,
+and the doc says which and why.
+
+## Prerequisites
+
+macOS, [IINA](https://iina.io) (everything here is verified against
+1.4.4 — the repo declares no minimum, but that's the version the behaviour
+notes below were checked on), and:
+
+```bash
+brew install go node ffmpeg
+```
+
+`nasm` is needed **only** if you build the shipped package (`make pack` /
+`make ffmpeg`) — the x86_64 ffmpeg slice assembles hand-written x86 assembly
+with it. The everyday dev loop never builds ffmpeg from source.
+
+## Dev loop
+
+```bash
+make dev
+```
+
+That builds the Go helper, symlinks Homebrew's `ffmpeg` into `plugin/bin/`,
+symlinks the root `Info.json` into `plugin/`, and registers the plugin
+directory with IINA.
+
+Then **restart IINA** and enable the plugin under Settings → Plugins. Restarting
+is not optional: the sidebar and standalone window are `WKWebView`s and don't
+hot-reload their JS. Plugin logs live in the same settings panel — select the
+plugin and open its console. Safari's Web Inspector can also attach to the
+plugin's webviews (`isInspectable` is on).
+
+On macOS 15+, grant IINA the **Local Network** permission the first time it
+serves a stream, or the Apple TV cannot reach it.
+
+## Tests
+
+```bash
+make test
+```
+
+That runs `go test ./...` in `helper/`, `node --test` over `plugin/tests/`, and
+the packaging shell tests. CI runs exactly this on `macos-15`, plus a full
+package build verified natively on both Apple Silicon and Intel.
+
+**Homebrew's `ffmpeg` is load-bearing for the test suite, not a convenience.**
+The helper's real-media end-to-end tests *skip themselves* when no system
+`ffmpeg` is found and `IINA_AIRPLAY_FFMPEG` is unset — so without it the suite
+goes green having never driven the pipeline through `ffmpeg` at all. If you're
+touching the transcode path, confirm those tests actually ran.
+
+### What you cannot test without hardware
+
+Casting itself needs a real Apple TV on the same LAN. Everything up to the
+handoff — probing the file, choosing remux vs. transcode, the HLS segments the
+helper serves, subtitle conversion, the packaged binaries — is covered by the
+automated suite and by pointing a browser or `ffprobe` at the helper's stream
+URL. Only the final "the TV picked it up and played it" step needs the device.
+
+Say so in your PR if you couldn't test that last step. It's an expected gap, not
+a problem — it just tells the maintainer what to check before merging.
+
+## Layout
+
+| Path | What lives there |
+| --- | --- |
+| `plugin/` | The IINA plugin: `main.js` (JSContext) and `sidebar.html` (the cast UI webview) |
+| `helper/` | The Go supervisor — spawns `ffmpeg`, serves HLS, watchdog, playlist |
+| `packaging/` | `build-ffmpeg.sh`, `pack.sh`, `verify.sh` and the release gates |
+| `docs/` | Design reasoning, the prototype record, the release runbook |
+| `Info.json` | The plugin manifest — **at the repo root**, see below |
+
+## Constraints that bite newcomers
+
+These are established facts, not guesses. Fuller detail in
+[`CLAUDE.md`](CLAUDE.md) and [`docs/prototype.md`](docs/prototype.md).
+
+- **The plugin API is JavaScript only.** No native code, no access to IINA's
+  render pipeline. This is why the design is a handoff rather than a mirror.
+- **`utils.exec` replaces the process environment** and sets only `LC_ALL`, so
+  `PATH` is empty in anything you spawn. The symptom is "command not found" for
+  a binary that is obviously installed. Always pass an absolute or `@data/` path.
+- **`sidebar.show()` crashes IINA when called from a `utils.exec` callback** —
+  those callbacks run off-main and trip an AutoLayout assertion. Call `sidebar.*`
+  only from menu/`onMessage` callbacks; let the page poll for background results.
+- **The first media load in a plugin webview flakes** (`error code=4`, fine on
+  reload). Retry once, automatically.
+- **`plugin/Info.json` is a gitignored symlink** created by `make dev`. Never
+  commit it — `raw.githubusercontent.com` serves a symlink's target path as
+  plain text, which would break IINA's update check for every existing user.
+- **Prefer remuxing over re-encoding, always.** A remux of an HEVC file takes
+  seconds; a re-encode of a UHD remux is not something anyone will wait for.
+
+### `master` is load-bearing — do not rename it
+
+IINA's update check fetches
+`raw.githubusercontent.com/<repo>/master/Info.json` — the repository root of the
+**`master` branch**, hardcoded, never the release. Renaming the default branch
+to `main` would silently cut every installed copy off from updates, and IINA
+reports that failure as a bland "No update found." Details in
+[`docs/releasing.md`](docs/releasing.md).
+
+## Branch and PR workflow
+
+Trunk-based. `master` is the single long-lived branch and stays green.
+
+- Branch off `master`, named `<your-gh-name>/<short-description>`.
+- Conventional-commit messages (`feat:`, `fix:`, `test:`, `docs:`, `chore:`).
+- Run `make test` before pushing — it's the same gate CI applies.
+- Open the PR into `master`. Reference the issue in the body (`Part of #N`, or
+  `Closes #N` when the merge fully finishes it).
+- PRs are **squash-merged**, so the PR title and body become the commit on
+  `master`. Write them as the changelog entry you'd want to read later.
+- CI's `test` job must pass, branches must be up to date, and review
+  conversations must be resolved before merge.
+
+## Issues
+
+Title every issue with a lowercase `[area]` prefix so a glance down the list
+finds everything touching one surface:
+
+| Prefix | Surface |
+| --- | --- |
+| `[plugin]` | `plugin/` — the JS entry point and the sidebar webview |
+| `[helper]` | `helper/` — the Go supervisor, ffmpeg pipeline, HLS server |
+| `[packaging]` | `packaging/` — the ffmpeg build, packing, verification, releases |
+| `[repo]` | Governance: CI, branch protection, tooling |
+| `[docs]` | Docs, design, README |
+
+Label a new issue when you open it: a **type** (`bug` / `enhancement` /
+`documentation`), a **priority** (`P1` / `P2` / `P3`), and a **size**
+(`size/XS` … `size/XL`), plus the area label it lands in. Priority and size are
+orthogonal — a change can be small but `P1`.
+
+New here? [`good first issue`](https://github.com/ozykhan/iina-airplay/labels/good%20first%20issue).
+
+### Reporting a cast bug
+
+Casting failures depend on the file, the Mac and the TV, so a report without
+those is rarely actionable. Include:
+
+- macOS version, Mac model, IINA version, plugin version
+- Apple TV model and tvOS version
+- `ffprobe` output for the file (or at least container, video codec, audio
+  codec, subtitle tracks)
+- The plugin console log from the failed attempt
+
+The bug report template asks for all of this.
+
+## Scope
+
+Reasonable additions: format coverage, subtitle handling, seeking, playlist
+behaviour, packaging robustness, tests. Things that are out of scope by design:
+native code in the plugin, mirroring IINA's actual video output, and anything
+that makes the common path re-encode when it could remux.
+
+If you're planning something large, open an issue first — a `[repo]` or design
+issue costs you nothing and saves a rewrite.
+
+## License
+
+By contributing you agree that your contributions are licensed under the
+repository's [MIT license](LICENSE).

--- a/README.md
+++ b/README.md
@@ -83,6 +83,19 @@ make test       # go test ./... in helper/, node --test over plugin/tests/,
                  # plus packaging/tests/verify.test.sh
 ```
 
+## Contributing
+
+Contributions are welcome. [`CONTRIBUTING.md`](CONTRIBUTING.md) covers the dev
+loop, the test suite, what you can verify without an Apple TV, the branch and
+issue conventions, and the handful of platform constraints that bite everyone
+once. New here? Look for
+[`good first issue`](https://github.com/ozykhan/iina-airplay/labels/good%20first%20issue).
+
+Trunk-based: branch off `master`, open a PR back into it, squash-merge; CI's
+`test` gate must pass. `master` is not a stylistic choice — IINA's update check
+reads `Info.json` from that branch by name, so renaming it would cut existing
+installs off from updates.
+
 ## Docs
 
 - `docs/feasibility.md` — why the direct route is closed, what's possible instead,

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -103,7 +103,9 @@ IINA looks.
 Two consequences worth keeping in mind:
 
 - **The update beacon is branch state, not release state.** A manifest fix
-  reaches existing users on a plain push to `master` — no new tag, no rebuild.
+  reaches existing users as soon as it lands on `master` — no new tag, no
+  rebuild. `master` is protected, so "lands on `master`" means a one-commit PR
+  that passes CI, not a direct push.
 - **`master` must carry the bumped `ghVersion`.** Tagging a release whose
   manifest never lands on `master` leaves the update check reading the old
   number, however correct the release page looks.


### PR DESCRIPTION
Readies the repo for external contributors, with [piperbox/piper](https://github.com/piperbox/piper) as the settings reference.

## Files in this PR

- **`CONTRIBUTING.md`** — prerequisites, dev loop, tests, layout, branch/PR/issue conventions, `[area]` title prefixes and the label scheme. Two things it records that aren't stated anywhere else a stranger would look:
  - Homebrew's `ffmpeg` is *load-bearing for the test suite*, not a convenience — the real-media e2e tests skip themselves when no system ffmpeg is found and `IINA_AIRPLAY_FFMPEG` is unset, so without it the suite goes green having never driven the pipeline through ffmpeg at all.
  - Casting to a real Apple TV is the one step no CI can cover. Contributors are told to say so in the PR rather than treat it as a failure.
  - Plus the constraints already in `CLAUDE.md` that bite everyone once: the empty `PATH` under `utils.exec`, the `sidebar.show()` crash from exec callbacks, the flaky first media load, and the `plugin/Info.json` symlink that must never be committed.
- **`.github/ISSUE_TEMPLATE/`** — a bug form that front-loads macOS/Mac/IINA/tvOS versions, `ffprobe` output and the plugin console log (a cast report without those is rarely actionable), a feature form with a scope check against native code and needless re-encoding, and a `config.yml` pointing at `CONTRIBUTING.md` and `docs/feasibility.md`.
- **`.github/PULL_REQUEST_TEMPLATE.md`** — including the "not verified (no device)" checkbox.
- **README** — a `## Contributing` section.
- **`docs/releasing.md`** — one corrected line, see below.

## `master` stays `master`

Piper uses `main`; this repo can't. IINA's update check fetches `raw.githubusercontent.com/<repo>/master/Info.json` — that branch by name, hardcoded, never the release. Renaming would cut every existing install off from updates and IINA would report it as a bland "No update found." That is now stated in the README and in `CONTRIBUTING.md` so nobody proposes the rename as a tidy-up.

## One doc correction

`docs/releasing.md` said a manifest fix reaches users "on a plain push to `master`". With branch protection now on, that is no longer the mechanism, so the line says what it now takes: a one-commit PR that passes CI. The substance — the beacon is branch state, not release state — is unchanged.

## Settings applied outside this PR

Already live on the repo, via the API:

| | before | now |
| --- | --- | --- |
| description / topics | none / none | set / 8 topics |
| merges | squash + merge + rebase | squash-only, title `PR_TITLE`, body `PR_BODY` |
| delete branch on merge | off | on |
| `master` protection | none | required check `test` (strict), linear history, conversation resolution, no force-push, no deletion, enforce-admins, 0 approvals |
| Dependabot alerts | off | on |
| labels | 10 defaults | + `P1`–`P3`, `size/XS`–`XL`, `epic`, `plugin`, `helper`, `packaging` |

Enforce-admins is on, so direct pushes to `master` — including a manifest-only hotfix — now go through a PR. That's the tradeoff behind the `releasing.md` edit above.

## Testing

`make test` passes locally. The issue forms parse as valid YAML. No code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)