### PR TITLE
ci: run the push leg on master only, not every branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,23 @@ name: ci
 # Tags are excluded: package.yml owns them and runs `make test` itself, so the
 # release chain is self-contained rather than depending on a second workflow's
 # status.
+#
+# The push trigger is master-only rather than '**' because a branch pushed to
+# this repo with a PR open satisfies BOTH triggers, and the concurrency group
+# below does not collapse the pair: github.ref is refs/heads/<branch> for the
+# push and refs/pull/N/merge for the pull_request, so the two runs land in
+# different groups and neither cancels the other. That billed two macos-15 runs
+# — the priciest runner here, at 10x the Linux rate — for every PR, both green,
+# both redundant.
+#
+# PRs keep their `test` check from the pull_request event, which is the context
+# master's branch protection actually requires, so the merge gate is unchanged;
+# merges to master still get a post-merge run from the push leg. The one thing
+# given up is CI on a branch pushed WITHOUT an open PR — deliberate, since the
+# gate that matters is the PR.
 on:
   push:
-    branches: ['**']
+    branches: [master]
   pull_request:
 
 permissions:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,7 +117,9 @@ Trunk-based. `master` is the single long-lived branch and stays green.
 
 - Branch off `master`, named `<your-gh-name>/<short-description>`.
 - Conventional-commit messages (`feat:`, `fix:`, `test:`, `docs:`, `chore:`).
-- Run `make test` before pushing — it's the same gate CI applies.
+- Run `make test` before pushing — it's the same gate CI applies. CI runs on
+  pull requests and on `master`, not on every branch push, so a work-in-progress
+  push with no PR open deliberately produces no run.
 - Open the PR into `master`. Reference the issue in the body (`Part of #N`, or
   `Closes #N` when the merge fully finishes it).
 - PRs are **squash-merged**, so the PR title and body become the commit on


### PR DESCRIPTION
Closes #5.

## The change

```diff
 on:
   push:
-    branches: ['**']
+    branches: [master]
   pull_request:
```

Plus the comment explaining why, and one line in `CONTRIBUTING.md`.

## Why the concurrency group didn't already handle this

This is the part worth recording, because the block reads as if the dedup is already in place:

```yaml
concurrency:
  group: ci-${{ github.ref }}
  cancel-in-progress: true
```

`github.ref` differs by event — `refs/heads/<branch>` for the push, `refs/pull/N/merge` for the pull_request. Two groups, so neither run cancels the other, and every PR billed two identical `macos-15` runs. macOS is the priciest runner here at 10× the Linux rate, so this was the most expensive job in the repo to run twice.

## What's unchanged

- PRs still get their `test` check from the `pull_request` event — the context `master`'s branch protection actually requires — so the merge gate is untouched.
- Merges to `master` still get a post-merge run from the push leg.
- Tags stay excluded; `package.yml` owns them and runs `make test` itself. That existing comment is preserved.

## What's given up

CI on a branch pushed with **no PR open**. Deliberate — the gate that matters is the PR — but it's a real change to the WIP-push feedback loop, so `CONTRIBUTING.md` now states it explicitly. A missing run should read as intended, not broken.

## Scope note

This only ever affected same-repo branches. An external contributor's push events fire in their fork, and a fork PR gets its check from the `pull_request` leg either way — so nothing changes for outside contributors.

## Testing

`make test` passes locally; the workflow parses as valid YAML with the expected triggers. The real proof is this PR itself: it should show exactly **one** `test` check instead of two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)