### PR TITLE
release: bump to 0.3.0 (ghVersion 3)

### DIFF
--- a/Info.json
+++ b/Info.json
@@ -1,9 +1,9 @@
 {
   "name": "AirPlay",
   "identifier": "dev.faruk.iina-airplay",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "ghRepo": "ozykhan/iina-airplay",
-  "ghVersion": 2,
+  "ghVersion": 3,
   "author": { "name": "Faruk Can Ozkan" },
   "description": "Cast the current file to an AirPlay device: remuxes to HLS, serves on the LAN, and hands the stream to the TV. IINA stays your remote.",
   "entry": "main.js",


### PR DESCRIPTION
Version bump only — no code changes.

- `version` → `0.3.0`, tag will be `v0.3.0`
- `ghVersion` → `3`, the number IINA's update check compares

Once this lands on `master`, the release sequence is: warm the ffmpeg cache
with a `package.yml` dispatch on `master`, then tag and push, then gate the
published result with `./packaging/check-published.sh v0.3.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)