### PR TITLE
release: publish before bumping master, and gate the switch

### DIFF
--- a/.claude/skills/cutting-a-release/SKILL.md
+++ b/.claude/skills/cutting-a-release/SKILL.md
@@ -11,7 +11,9 @@ This skill owns sequence and gates. Read the doc; nothing here restates it.
 ## The rule
 
 **A release is not done when CI is green. It is done when
-`./packaging/check-published.sh <tag>` passes.**
+`./packaging/check-published.sh <tag>` passes** — the full two-sided form, run
+after the bump has been merged. `--release-only` is a mid-sequence gate, not
+that one.
 
 IINA installs and updates through two different mechanisms, and every failure
 mode in both is silent: the release page renders correctly, every job is a green
@@ -19,22 +21,35 @@ tick, and the release reaches nobody. `v0.2.0` shipped exactly that way.
 
 ## Sequence
 
+**The bump lands on `master` LAST.** `master` is the update beacon, so merging
+it before the asset is published tells every install an update exists and then
+hands it the previous release. Publish first; merge last.
+
 1. Bump `version` **and** `ghVersion` in `Info.json` — the one at the repository
-   root. Commit it to `master`.
+   root — on a `release/v<version>` branch. Open the PR. **Do not merge it.**
 2. **Warm the cache before tagging:** `gh workflow run package.yml --ref master`,
    and let it finish. Tag refs cannot read caches written on PRs or other tags.
    Skipping this costs about 8 minutes on the tag build.
-3. `./packaging/check-release.sh v<version>` locally, then push the tag.
+3. `./packaging/check-release.sh v<version>` locally, then tag the **branch
+   head** and push the tag. Not `master` — it does not carry the bump yet.
 4. Read the `verify-intel` **log**, not its checkmark — the three lines the doc
    names.
 5. Review the draft, then publish: **Set as a pre-release** unchecked, **Set as
    the latest release** checked.
-6. `./packaging/check-published.sh v<version>`.
+6. `./packaging/check-published.sh --release-only v<version>`.
+7. **Merge the PR.** The only irreversible step, which is why step 6 gates it.
+8. `./packaging/check-published.sh v<version>`.
 
 ## Red flags — you are about to ship to nobody
 
-- "CI is green, so the release is done." → step 6 has not run.
+- "CI is green, so the release is done." → step 8 has not run.
+- **Merged the bump before publishing.** → you have re-opened the window this
+  ordering exists to close: `master` now advertises a version whose asset is not
+  up, so every update check in the gap hands out the *previous* release. Publish
+  and finish the sequence; do not merge anything else meanwhile.
+- "I'll merge the PR first so I don't forget." → that is the failure above.
 - "The release page looks right." → that is how every one of these failures looks.
+  Step 6 exists so the merge is gated by a command instead of by that glance.
 - `version` bumped but not `ghVersion`. Existing installs are never offered it.
 - The bump never landed on `master`. The update check reads the **branch**, not
   the release, so a perfect release page changes nothing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,8 +56,12 @@ From reading the IINA source (`github.com/iina/iina`) and Apple's docs:
   `api.github.com/repos/<ghRepo>/releases/latest` and takes the first asset
   ending `.iinaplgz`. The update check reads
   `raw.githubusercontent.com/<ghRepo>/master/Info.json` — the **repository root
-  of `master`**, never the release — and compares its `ghVersion`; only then
-  does it fetch the asset. This is why `Info.json` lives at the repo root and
+  of `master`**, never the release — and compares its `ghVersion` against **the
+  installed package's own**; only then does it fetch the asset. So the shipped
+  `.iinaplgz` and `master` must carry the same number, and the bump is merged to
+  `master` **last**, after the release is published — otherwise the beacon
+  advertises a version whose asset is not up yet and the update hands out the
+  previous release. This is why `Info.json` lives at the repo root and
   `packaging/pack.sh` copies it into the package. IINA 1.4.4 folds a failed
   fetch and "no newer version" into one branch (`JavascriptPlugin.swift`,
   `checkForUpdates`), so a 404 there surfaces as **"No update found."** with no

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -7,7 +7,13 @@ publish one that does not.
 
 ## Cutting a release
 
-1. **Bump both numbers in `Info.json` — the one at the repository root.**
+**The order below is load-bearing.** The bump to `master` comes *last*, after
+the release is published — see "The skew has a direction" below for why. Do not
+merge the bump early to get it out of the way; that is the one mistake this
+sequence exists to prevent.
+
+1. **Bump both numbers in `Info.json` — the one at the repository root — on a
+   release branch, and open the PR without merging it.**
 
    - `version` — the semver string, e.g. `0.2.0`. The tag must be `v` + this.
    - `ghVersion` — an **Int**, a monotonic counter. **Not** the semver string.
@@ -21,60 +27,105 @@ publish one that does not.
    The manifest's **location** is load-bearing for the same reason, and cost a
    release to learn — see "Two mechanisms" below.
 
-2. **Commit, then tag and push.**
-
    ```sh
-   git tag v0.2.0
-   git push origin master v0.2.0
+   git checkout -b release/v0.3.0
+   # edit Info.json, commit
+   gh pr create --base master
    ```
 
-3. **Watch the chain.** `gh run watch`. `build` gates the tag first, so a
+2. **Warm the ffmpeg cache.** `gh workflow run package.yml --ref master`, and
+   let it finish. Actions caches are scoped by ref: only ones written on the
+   default branch are readable from a tag, so a PR run warms nothing. Skipping
+   this costs about eight minutes on the tag build. See "Rebuilding without
+   releasing" below.
+
+3. **Tag the branch head and push the tag.** Not `master` — `master` does not
+   carry the bump yet, and will not until step 9.
+
+   ```sh
+   ./packaging/check-release.sh v0.3.0   # seconds, before the build
+   git tag v0.3.0
+   git push origin v0.3.0
+   ```
+
+4. **Watch the chain.** `gh run watch`. `build` gates the tag first, so a
    mismatch fails in seconds. On GitHub's `macos-15` runner a cold ffmpeg
    cache costs about 5 minutes to build and about 9 minutes for the whole
    `build` → `verify-intel` chain; warm, `build` finishes in under 2 minutes.
    A local `make pack` is considerably slower on a developer machine — see
    `README.md`.
 
-4. **Read the `verify-intel` log**, not just its checkmark. Three lines are the
+5. **Read the `verify-intel` log**, not just its checkmark. Three lines are the
    point of the job:
 
    - `runner architecture: x86_64`
    - `verify: note — the native slice is x86_64, so its assertions run natively`
    - `test-package: driving iina-airplay.iinaplgz through the helper suite on x86_64`
 
-5. **Review the draft release.** Confirm exactly one `.iinaplgz` asset, its
+6. **Review the draft release.** Confirm exactly one `.iinaplgz` asset, its
    `.sha256` sidecar, and notes naming the FFmpeg version, upstream source URL
    and source SHA-256 — that last part is the LGPL obligation, not decoration.
 
-6. **Publish it.** The publish dialog offers two checkboxes — leave **Set as
+7. **Publish it.** The publish dialog offers two checkboxes — leave **Set as
    a pre-release** unchecked, and confirm **Set as the latest release** is
    checked. Either one wrong and `api.github.com/.../releases/latest` skips
    this release exactly as it skips a draft: every check stays green, the
    release page looks fine, and nothing reaches users.
 
-7. **Gate the published result.** Both mechanisms, one command:
+8. **Prove the release half is live, before throwing the switch.**
 
    ```sh
-   ./packaging/check-published.sh v0.2.0
+   ./packaging/check-published.sh --release-only v0.3.0
    ```
 
-   `check-release.sh` gates the tag before the build; this gates what actually
-   shipped. It asserts `/releases/latest` names this tag with exactly one
-   `.iinaplgz`, **and** that `master`'s manifest is readable at the repo root
-   with a matching version and an Int `ghVersion` — the half that nothing
-   checked before `v0.2.0` shipped to nobody. See "Two mechanisms" below.
+   Asserts `/releases/latest` names this tag, is neither a draft nor a
+   pre-release, and carries exactly one `.iinaplgz`. It does not look at
+   `master` at all — at this point `master` is *supposed* to disagree.
 
-8. **Install it the way a stranger would.** IINA → Settings → Plugins →
-   Install → `ozykhan/iina-airplay`. Not the local-package path — the point is
-   to exercise the download-from-release path, which is the one thing local
-   packaging can never test. Cast one real file, then confirm nothing picked up
-   quarantine:
+9. **Merge the PR.** This is the moment the release turns on for every existing
+   install, and it is the only irreversible step in the sequence — which is why
+   step 8 gates it with a command rather than a glance at the release page.
 
-   ```sh
-   xattr -r ~/Library/Application\ Support/com.colliderli.iina/plugins/*/bin/
-   ```
+10. **Gate the published result.** Both mechanisms, one command:
 
-   Expect `com.apple.provenance` at most, and never `com.apple.quarantine`.
+    ```sh
+    ./packaging/check-published.sh v0.3.0
+    ```
+
+    `check-release.sh` gates the tag before the build; this gates what actually
+    shipped. It asserts `/releases/latest` names this tag with exactly one
+    `.iinaplgz`, **and** that `master`'s manifest is readable at the repo root
+    with a matching version and an Int `ghVersion` — the half that nothing
+    checked before `v0.2.0` shipped to nobody. See "Two mechanisms" below.
+
+    **A release is not done until this passes.** Not when CI is green, not when
+    the release page looks right.
+
+11. **Install it the way a stranger would.** IINA → Settings → Plugins →
+    Install → `ozykhan/iina-airplay`. Not the local-package path — the point is
+    to exercise the download-from-release path, which is the one thing local
+    packaging can never test. Cast one real file, then confirm nothing picked up
+    quarantine:
+
+    ```sh
+    xattr -r ~/Library/Application\ Support/com.colliderli.iina/plugins/*/bin/
+    ```
+
+    Expect `com.apple.provenance` at most, and never `com.apple.quarantine`.
+
+### If the build fails after the tag is pushed
+
+The tag is on an unmerged branch, so nothing user-facing has moved: `master`
+still describes the previous release and `releases/latest` still serves it.
+Delete the tag, fix the branch, tag again.
+
+```sh
+git push --delete origin v0.3.0 && git tag -d v0.3.0
+```
+
+This is strictly cheaper than the failure it replaces. Under the old order the
+bump was already on `master`, so a failed build left the beacon announcing a
+version whose asset did not exist.
 
 ## Two mechanisms, two URLs
 
@@ -109,6 +160,48 @@ Two consequences worth keeping in mind:
 - **`master` must carry the bumped `ghVersion`.** Tagging a release whose
   manifest never lands on `master` leaves the update check reading the old
   number, however correct the release page looks.
+
+### The skew has a direction
+
+The number IINA compares `master`'s `ghVersion` against is **the installed
+package's own** `ghVersion`, read from the manifest inside the `.iinaplgz` the
+user already has. In 1.4.4 (`JavascriptPlugin.swift`, `checkForUpdates`):
+
+```swift
+if let ghVersion = githubVersion, let ghRepo = githubRepo {
+  Just.get("https://raw.githubusercontent.com/\(ghRepo)/master/Info.json", ...) { result in
+    if let json = result.json as? [String: Any],
+       let newGHVersion = json["ghVersion"] as? Int,
+       let newVersion = json["version"] as? String,
+       newGHVersion > ghVersion {          // ghVersion == githubVersion, this install's own
+      handler(newVersion)
+```
+
+Two things follow.
+
+**The shipped package must carry the same `ghVersion` as `master`.** Bumping
+only `master` — letting the release workflow rewrite the manifest as a last
+step, say — is worse than any window it closes: every install would keep
+reporting the old number, `master` would compare greater forever, and IINA
+would offer an update on every check that re-downloads the same package.
+
+**So the bump must be in the tagged tree, and only its arrival on `master` can
+move.** That arrival is the switch, and the skew it creates has a safe
+direction and a dangerous one:
+
+| State | Existing installs | New installs |
+| --- | --- | --- |
+| `master` ahead of `releases/latest` | offered an update, handed the **old** asset | fine |
+| `releases/latest` ahead of `master` | no update offered yet; they wait | get the new version, correctly told they are current |
+
+Publishing before merging keeps the skew in the bottom row for the few minutes
+it exists, and in no row at all the rest of the time. Cutting `v0.3.0` the other
+way round left about ten minutes of the top row.
+
+> On IINA's `develop` branch this is `checkNewVersion()`, which throws on a
+> failed fetch instead of folding it into `nil` — so a future IINA will report a
+> missing manifest as an error rather than as "No update found." The comparison
+> itself is unchanged, and 1.4.4 is what users are running.
 
 `plugin/Info.json` is a gitignored symlink created by `make dev`, because a
 plugin directory must carry its own manifest for IINA to load it. Never commit

--- a/docs/superpowers/specs/2026-08-31-release-ordering-design.md
+++ b/docs/superpowers/specs/2026-08-31-release-ordering-design.md
@@ -1,0 +1,220 @@
+# Release ordering: closing the update window
+
+**Status:** approved, not yet implemented
+**Date:** 2026-08-31
+**Applies from:** v0.4.0. v0.3.0 shipped under the old order and is correct now
+that both sides agree; nothing needs re-cutting.
+
+## The problem
+
+Cutting v0.3.0 left a window of roughly ten minutes in which IINA offered
+existing installs an update and handed them the **previous** release's package.
+
+The cause is ordering. The bump to `Info.json` lands on `master` first (it must,
+to be in the tagged tree), and `master` is the update beacon — so the beacon
+announces the new version while `releases/latest` still points at the old one.
+For the length of the tag build plus however long the draft sits unreviewed,
+every update check in the world resolves to a lie.
+
+## What IINA actually compares
+
+From `iina/JavascriptPlugin.swift`, `checkNewVersion()`:
+
+```swift
+guard let ghVersion = githubVersion, let ghRepo = githubRepo else { ... }
+Just.get("https://raw.githubusercontent.com/\(ghRepo)/master/Info.json", ...) { result in
+    if result.ok,
+       let json = result.json as? [String: Any],
+       let newGHVersion = json["ghVersion"] as? Int,
+       let newVersion = json["version"] as? String {
+        if newGHVersion > ghVersion { /* offer the update */ }
+```
+
+`githubVersion` is read from the **installed package's own** `Info.json`. So the
+comparison is:
+
+> `master`'s `ghVersion`  vs.  the `ghVersion` inside the package the user has.
+
+Two consequences, and the whole design rests on them:
+
+1. **The shipped package must carry the same `ghVersion` as `master`.** Bumping
+   only `master` — the obvious reading of "let the release workflow update
+   `Info.json` as its last step" — is worse than the gap it fixes. Every install
+   would keep reporting the old number, `master` would always compare greater,
+   and IINA would offer an update on every check forever, re-downloading the
+   same package each time.
+
+2. **The skew has a direction, and only one direction is harmful.**
+
+   | State | Existing installs | New installs |
+   | --- | --- | --- |
+   | `master` ahead of `releases/latest` | offered an update, handed the **old** asset | fine |
+   | `releases/latest` ahead of `master` | no update offered yet; they wait | get the new version, correctly told they are current |
+
+## The invariant
+
+> **`master`'s `ghVersion` may never exceed the `ghVersion` inside the package
+> at `releases/latest`.**
+
+Everything below follows from it. The bump to `master` stops being step one and
+becomes the switch that turns the release on, thrown only once the asset is
+provably in place.
+
+## New sequence
+
+1. Branch `release/vX.Y.Z`, bump `version` **and** `ghVersion` in the root
+   `Info.json`, open the PR. **Do not merge it.**
+2. Warm the ffmpeg cache: `gh workflow run package.yml --ref master`. Unchanged,
+   and still worth about eight minutes on the tag build.
+3. Tag the **branch head** and push the tag. CI gates, builds, verifies, drafts.
+4. Read the `verify-intel` log — the three lines `docs/releasing.md` names.
+   Review the draft.
+5. Publish. Pre-release unchecked, "Set as the latest release" checked.
+6. `./packaging/check-published.sh --release-only vX.Y.Z`.
+7. **Merge the PR.** This is the moment the release turns on for existing users.
+8. `./packaging/check-published.sh vX.Y.Z`.
+
+Between 5 and 7 the skew is the safe direction. Before 5 there is no skew at
+all: `master` and `releases/latest` both still describe the previous release.
+
+## Changes
+
+### `packaging/check-release.sh` — previous-tag lookup
+
+The current lookup is reachability-based:
+
+```bash
+prev="$(git -C "$ROOT" describe --tags --abbrev=0 "$TAG^" 2>/dev/null || true)"
+```
+
+Under the new order the tag sits on an unmerged branch. Squash-merging that
+branch puts an equivalent commit on `master` at a different SHA, so the tag
+never enters `master`'s history — and the next release's lookup walks back past
+it. Gating v0.4.0 would find v0.2.0, compare `ghVersion 4 > 2`, and pass even if
+the bump from 3 had been forgotten. It fails **open**, which is the one
+direction this gate must not fail.
+
+Replace it with a version-sorted lookup — the highest tag that exists, rather
+than the nearest one reachable:
+
+```bash
+prev="$(git -C "$ROOT" tag --sort=-v:refname --list 'v*' | grep -Fxv "$TAG" | head -n1)"
+```
+
+- Independent of merge strategy. Squash merges stay.
+- Strictly stronger: it compares against the highest release in existence, so a
+  ghVersion that does not exceed *every* prior release is rejected.
+- Works before the tag exists locally as well as after, since `grep -Fxv`
+  removes `$TAG` when present and is a no-op when it is not. The old lookup
+  reported "first release; skipping" when run pre-tag — a skip that read as
+  reassurance while checking nothing.
+
+Keep: the shallow-clone guard (its rationale shifts from "needs history" to
+"needs the full tag list", and its failure mode is the same silent skip), the
+dual-path `Info.json` / `plugin/Info.json` read for v0.1.0 and v0.2.0, and every
+existing assertion. Note for the implementer: this file follows the bash 3.2
+split-declaration convention used across `packaging/`.
+
+**Behaviour change to call out in review:** the gate now fires in cases where it
+previously skipped itself. That is the fix, not a side effect.
+
+**Verified against a throwaway repository** (tags v0.1.0, v0.2.0, v0.9.0,
+v0.10.0 on `master`; v0.11.0 on a branch, squash-merged):
+
+| Query | Result |
+| --- | --- |
+| proposed lookup, gating v0.11.0 | `v0.10.0` |
+| old lookup from `master`'s tip, as the next release would run it | `v0.10.0` — **v0.11.0 skipped**, the fail-open hole, reproduced |
+| sort order | `v0.11.0 v0.10.0 v0.9.0 v0.2.0 v0.1.0` — version-aware, so v0.10.0 outranks v0.9.0 |
+| proposed lookup pre-tag, gating v0.12.0 | `v0.11.0` |
+| no tags at all | empty, so the "first release" skip is preserved |
+
+### `packaging/check-published.sh` — `--release-only`
+
+Add a flag that asserts the install half alone:
+
+- `/releases/latest` names this tag
+- not a draft, not a pre-release
+- exactly one `.iinaplgz` asset
+
+It must **skip the `raw.githubusercontent.com` fetch entirely** rather than
+fetching and ignoring the result — under the new order that manifest is
+*expected* to disagree, and a fetch whose outcome is discarded invites someone
+to later "fix" the discrepancy it prints.
+
+The success line must not be mistakable for the full gate:
+
+```
+check-published: OK (release half only) — vX.Y.Z is /releases/latest with one
+.iinaplgz. master's manifest was NOT checked; run without --release-only after
+merging the bump.
+```
+
+Argument parsing accepts the flag in either position. An unknown flag is an
+error, not a tag.
+
+The default two-sided behaviour is unchanged, including its message and its
+exit codes. Step 8 still runs exactly what it runs today.
+
+### Tests
+
+Both scripts have fixture-driven suites that already cover their existing
+branches. Add:
+
+`packaging/tests/check-release.test.sh` — `make_repo` builds one commit per
+`version:ghVersion:tag[:layout]` tuple, so it needs a way to place a commit on a
+branch off `master` rather than on it.
+
+- the version-sorted lookup picks the **highest** tag, not the nearest
+  reachable, where the two differ
+- a tag on an unmerged branch is gated against the highest tag on `master`, and
+  a forgotten bump there **fails** (the regression this change exists to prevent)
+- `v0.10.0` sorts above `v0.9.0` — `-v:refname` is version-aware; a lexical sort
+  would invert this and silently weaken the gate
+- no tags at all still reports "first release" and skips
+
+`packaging/tests/check-published.test.sh` — `make_endpoints` already serves both
+endpoints over `file://`.
+
+- `--release-only` passes on fixtures where the full check fails **because the
+  raw manifest is stale** — the exact mid-sequence state of step 6
+- `--release-only` still fails on a draft, a pre-release, a wrong tag, and on
+  zero or two `.iinaplgz` assets
+- `--release-only` passes when the raw manifest is **absent entirely**, proving
+  the fetch is skipped rather than fetched-and-ignored
+- an unknown flag exits non-zero and is not treated as a tag
+
+### Docs
+
+`docs/releasing.md` — the reordered sequence, and a new subsection on why the
+skew has a direction, carrying the `checkNewVersion` snippet and the two-row
+table above. That the comparison target is the *installed package's* number is
+the load-bearing fact of this design and is currently written down nowhere.
+Also document tag recovery: a build that fails now leaves a tag on an unmerged
+branch, recovered with `git push --delete origin vX.Y.Z`, re-tag, re-push —
+strictly cheaper than the old failure mode, where the beacon was already live
+and lying.
+
+`.claude/skills/cutting-a-release/SKILL.md` — the new step order, plus a red
+flag: *"Merged the bump before publishing the release" → you have re-opened the
+window this ordering exists to close.*
+
+`CLAUDE.md` — the install/update bullet gains the comparison target, in one
+clause.
+
+## Out of scope
+
+- Automating the merge. It needs a token that bypasses branch protection and
+  merges to `master` without review, to save one command.
+- Any change to `package.yml`. It already drafts and stops, which is exactly
+  right; the draft state is what makes the safe ordering possible at all.
+- Re-cutting v0.3.0.
+
+## Success criteria
+
+- `make test` passes, including the new cases.
+- A dry run of the new lookup against the real repository reports v0.3.0 as the
+  previous tag when gating v0.4.0, from a branch, after a squash merge.
+- Cutting v0.4.0 by the new sequence leaves no interval in which
+  `raw.githubusercontent.com/ozykhan/iina-airplay/master/Info.json` reports a
+  `ghVersion` higher than the one inside the package at `releases/latest`.

--- a/packaging/check-published.sh
+++ b/packaging/check-published.sh
@@ -23,8 +23,26 @@ API_BASE="${CHECK_PUBLISHED_API_BASE:-https://api.github.com}"
 RAW_BASE="${CHECK_PUBLISHED_RAW_BASE:-https://raw.githubusercontent.com}"
 INFO="$ROOT/Info.json"
 
-TAG="${1:-}"
-[ -n "$TAG" ] || { echo "check-published: usage: check-published.sh <tag>" >&2; exit 2; }
+# --release-only gates the INSTALL half alone. The release sequence publishes
+# the release before the bump lands on master, so that master's beacon never
+# announces a version whose asset is not up yet — which leaves a deliberate
+# window in which the update half is SUPPOSED to disagree. This flag is what
+# gates the irreversible step in that window: merging the bump. Run the gate
+# without it afterwards; that is still the check that says the release is done.
+RELEASE_ONLY=0
+TAG=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --release-only) RELEASE_ONLY=1 ;;
+    -*) echo "check-published: unknown option $1" >&2; exit 2 ;;
+    *)
+      [ -z "$TAG" ] || { echo "check-published: unexpected extra argument $1" >&2; exit 2; }
+      TAG="$1"
+      ;;
+  esac
+  shift
+done
+[ -n "$TAG" ] || { echo "check-published: usage: check-published.sh [--release-only] <tag>" >&2; exit 2; }
 
 fail() { echo "check-published: FAILED — $*" >&2; exit 1; }
 
@@ -46,16 +64,25 @@ fetch() { curl -fsSL "$1" > "$2" 2>/dev/null; }
 fetch "$API_BASE/repos/$ghrepo/releases/latest" "$TMPD/latest.json" \
   || fail "cannot read releases/latest for $ghrepo — is anything published?"
 
+# Skipped entirely under --release-only, rather than fetched and ignored: in
+# that window the manifest on master is EXPECTED to disagree, and a fetch whose
+# result is discarded invites someone to later "fix" the discrepancy it prints.
+# The empty path below tells the checker there is nothing to judge.
+#
 # A miss here is THE silent one, so it is named for what it breaks rather than
 # reported as a bare HTTP error.
-if ! fetch "$RAW_BASE/$ghrepo/master/Info.json" "$TMPD/raw.json"; then
+if [ "$RELEASE_ONLY" = 1 ]; then
+  raw_arg=""
+elif ! fetch "$RAW_BASE/$ghrepo/master/Info.json" "$TMPD/raw.json"; then
   fail "IINA's update check reads $RAW_BASE/$ghrepo/master/Info.json and it is not there.
     Existing users will be told \"No update found.\" no matter how correct the
     release is — IINA folds a failed fetch and \"no newer version\" into one
     branch. The manifest must be committed at the REPOSITORY ROOT of master."
+else
+  raw_arg="$TMPD/raw.json"
 fi
 
-/usr/bin/python3 - "$TAG" "$TMPD/latest.json" "$TMPD/raw.json" <<'PY'
+/usr/bin/python3 - "$TAG" "$TMPD/latest.json" "$raw_arg" <<'PY'
 import json, sys
 
 tag, latest_path, raw_path = sys.argv[1], sys.argv[2], sys.argv[3]
@@ -73,7 +100,9 @@ def load(path, what):
 
 
 latest = load(latest_path, "releases/latest")
-raw = load(raw_path, "the manifest on master")
+# An empty raw_path is --release-only: the manifest on master was never
+# fetched, because in that window it is expected to disagree.
+raw = load(raw_path, "the manifest on master") if raw_path else None
 
 # --- the install mechanism ---------------------------------------------------
 if latest.get("tag_name") != tag:
@@ -100,8 +129,10 @@ if len(plgz) != 1:
     )
 
 # --- the update mechanism ----------------------------------------------------
-raw_version = raw.get("version")
-if raw_version != expected_version:
+raw_version = raw.get("version") if raw is not None else None
+if raw is None:
+    pass
+elif raw_version != expected_version:
     problems.append(
         f"the manifest on master says version {raw_version!r}, but this tag is {tag!r} "
         f"(expected {expected_version!r}). IINA's update check reads master, not the "
@@ -109,8 +140,8 @@ if raw_version != expected_version:
         f"this release."
     )
 
-gh = raw.get("ghVersion")
-if isinstance(gh, bool) or not isinstance(gh, int):
+gh = raw.get("ghVersion") if raw is not None else None
+if raw is not None and (isinstance(gh, bool) or not isinstance(gh, int)):
     problems.append(
         f"ghVersion on master must be a JSON integer, not {type(gh).__name__} — "
         f"IINA casts it as? Int, and a wrong type silently disables update checks"
@@ -122,9 +153,19 @@ if problems:
         print(f"  - {p}", file=sys.stderr)
     sys.exit(1)
 
-print(
-    f"check-published: OK — {tag} is /releases/latest with one .iinaplgz, and "
-    f"master's manifest reports version {raw_version} / ghVersion {gh}, so IINA "
-    f"offers the update to existing installs."
-)
+# Two distinct messages, because these are two distinct claims and the weaker
+# one is read mid-sequence. A bare "OK" here could be mistaken for the full
+# gate, which is the one that says the release is actually done.
+if raw is None:
+    print(
+        f"check-published: OK (release half only) — {tag} is /releases/latest with "
+        f"one .iinaplgz. master's manifest was NOT checked; run without "
+        f"--release-only after merging the bump."
+    )
+else:
+    print(
+        f"check-published: OK — {tag} is /releases/latest with one .iinaplgz, and "
+        f"master's manifest reports version {raw_version} / ghVersion {gh}, so IINA "
+        f"offers the update to existing installs."
+    )
 PY

--- a/packaging/check-release.sh
+++ b/packaging/check-release.sh
@@ -54,8 +54,8 @@ ghversion="$(sed -n 2p <<<"$info_fields")"
 [ "$TAG" = "v$version" ] \
   || fail "tag $TAG does not match Info.json version $version — expected tag v$version"
 
-# A shallow clone truncates history in exactly the way that makes the
-# previous-tag lookup below come back empty whether or not a previous tag
+# A shallow clone arrives without the tag list, in exactly the way that makes
+# the previous-tag lookup below come back empty whether or not a previous tag
 # actually exists — the empty result is ambiguous, and letting it fall
 # through unchecked resolves that ambiguity in the dangerous direction: a
 # forgotten ghVersion bump on a truncated checkout would sail through as if
@@ -65,17 +65,33 @@ if ! is_shallow="$(git -C "$ROOT" rev-parse --is-shallow-repository 2>&1)"; then
   fail "cannot determine whether $ROOT has full git history: $is_shallow"
 fi
 [ "$is_shallow" = "false" ] \
-  || fail "checkout has truncated history (shallow clone) — the ghVersion monotonicity check needs full history with tags; re-run actions/checkout with fetch-depth: 0"
+  || fail "checkout has truncated history (shallow clone) — the ghVersion monotonicity check needs the full tag list; re-run actions/checkout with fetch-depth: 0"
 
-# --abbrev=0 on the tag's PARENT gives the nearest tag strictly before this
-# one. Requires unshallowed history with tags: actions/checkout must run with
-# fetch-depth: 0, or this finds nothing and the monotonicity check is skipped
-# exactly when it is needed.
-prev="$(git -C "$ROOT" describe --tags --abbrev=0 "$TAG^" 2>/dev/null || true)"
+# The highest release tag that exists, rather than the nearest one reachable
+# from this commit. Reachability is the wrong question here: the release
+# sequence tags the release BRANCH (so master's beacon never announces a
+# version whose asset is not published yet — see docs/releasing.md), and
+# squash-merging that branch puts an equivalent commit on master at a
+# different sha. The tagged commit therefore never enters master's history,
+# and `git describe` on the next release walks straight past it to the release
+# before last. That miss fails OPEN — it compares against an older, lower
+# ghVersion and waves a forgotten bump through — which is the one direction
+# this gate must never fail.
+#
+# -v:refname sorts version-aware, so v0.10.0 outranks v0.9.0; a lexical sort
+# would invert that and silently compare against the wrong release. grep -Fxv
+# drops $TAG itself when it is already created, and is a harmless no-op when
+# it is not — so this works both in CI (tag exists) and when a maintainer
+# checks the bump locally before pushing anything (tag does not).
+prev="$(git -C "$ROOT" tag --sort=-v:refname --list 'v*' 2>/dev/null | grep -Fxv "$TAG" | head -n1)"
 
 if [ -z "$prev" ]; then
   echo "check-release: no tag before $TAG; skipping the ghVersion monotonicity check (first release)"
 else
+  # Read the previous tag's manifest out of git rather than the working tree:
+  # under the branch-tagging sequence the previous tag may not be an ancestor
+  # of anything checked out here.
+  #
   # Info.json moved from plugin/ to the repository root, so the previous tag's
   # copy may be at either path: v0.1.0 and v0.2.0 predate the move, everything
   # from v0.3.0 on does not. Try the root first — it is the authoritative

--- a/packaging/tests/check-published.test.sh
+++ b/packaging/tests/check-published.test.sh
@@ -35,12 +35,15 @@ JSON
   echo "$d"
 }
 
+# RELEASE_ONLY, when set, is passed through as an extra argument, so the same
+# fixtures and the same expect_* helpers drive both modes.
+RELEASE_ONLY=""
 run_check() {
   local d="$1" tag="$2"
   CHECK_PUBLISHED_ROOT="$d/local" \
   CHECK_PUBLISHED_API_BASE="file://$d/api" \
   CHECK_PUBLISHED_RAW_BASE="file://$d/raw" \
-    "$CHECK" "$tag" 2>&1
+    "$CHECK" ${RELEASE_ONLY:+"$RELEASE_ONLY"} "$tag" 2>&1
 }
 
 expect_ok() {
@@ -110,6 +113,69 @@ expect_fail "master's manifest was never bumped" "$behind" v0.2.0 "0.1.0"
 strver="$(make_endpoints strver "$GOOD_LATEST" \
   '{"name":"AirPlay","version":"0.2.0","ghRepo":"ozykhan/iina-airplay","ghVersion":"2","entry":"main.js"}')"
 expect_fail "ghVersion on master is a string" "$strver" v0.2.0 "integer"
+
+# --- --release-only: the half that must be true before the bump is merged -----
+# The release sequence publishes the release BEFORE the bump lands on master, so
+# that master's beacon never announces a version whose asset is not up yet. That
+# leaves a deliberate intermediate state — release live, master still on the old
+# version — in which the full two-sided gate is SUPPOSED to fail. --release-only
+# is what gates the irreversible step (merging the bump) in that state.
+RELEASE_ONLY="--release-only"
+
+# The step-6 state itself: the same fixture the full gate rejects above.
+expect_ok "--release-only passes while master's manifest is still behind" "$behind" v0.2.0
+
+# Proves the raw fetch is SKIPPED, not fetched and ignored. Fetching a manifest
+# whose result is discarded invites someone to later "fix" the discrepancy it
+# prints, which would reintroduce the coupling this flag exists to break.
+expect_ok "--release-only passes with no manifest on master at all" "$missing" v0.2.0
+
+# The install half must still be gated exactly as hard.
+expect_fail "--release-only still rejects a stale releases/latest" "$stale" v0.2.0 "latest"
+expect_fail "--release-only still rejects a pre-release" "$pre" v0.2.0 "pre-release"
+expect_fail "--release-only still rejects a missing asset" "$noasset" v0.2.0 "iinaplgz"
+expect_fail "--release-only still rejects two .iinaplgz assets" "$two" v0.2.0 "exactly one"
+
+# The success line must not be mistakable for the full gate — this flag is run
+# mid-sequence, and someone reading a bare "OK" could take it for step 8.
+relonly_out="$(run_check "$behind" v0.2.0)"
+if grep -q "NOT checked" <<<"$relonly_out"; then
+  echo "ok: --release-only says master's manifest was not checked"
+else
+  echo "FAIL: --release-only — success line does not say master was unchecked:"
+  echo "$relonly_out" | sed 's/^/    /'
+  fails=$((fails + 1))
+fi
+
+RELEASE_ONLY=""
+
+# The flag is accepted after the tag as well as before it.
+after_out="$(CHECK_PUBLISHED_ROOT="$behind/local" \
+  CHECK_PUBLISHED_API_BASE="file://$behind/api" \
+  CHECK_PUBLISHED_RAW_BASE="file://$behind/raw" \
+  "$CHECK" v0.2.0 --release-only 2>&1)"
+if [ $? -eq 0 ]; then
+  echo "ok: --release-only is accepted after the tag"
+else
+  echo "FAIL: --release-only after the tag — expected exit 0:"
+  echo "$after_out" | sed 's/^/    /'
+  fails=$((fails + 1))
+fi
+
+# An unknown flag must be an error, never mistaken for a tag: silently treating
+# --relase-only as the tag would compare it against releases/latest, fail with a
+# tag-mismatch message, and send the reader hunting the wrong problem.
+typo_out="$(CHECK_PUBLISHED_ROOT="$good/local" \
+  CHECK_PUBLISHED_API_BASE="file://$good/api" \
+  CHECK_PUBLISHED_RAW_BASE="file://$good/raw" \
+  "$CHECK" --relase-only v0.2.0 2>&1)"
+if [ $? -ne 0 ] && grep -qi "unknown option" <<<"$typo_out"; then
+  echo "ok: an unknown flag is rejected as a flag, not treated as a tag"
+else
+  echo "FAIL: unknown flag — expected a non-zero exit naming the unknown option:"
+  echo "$typo_out" | sed 's/^/    /'
+  fails=$((fails + 1))
+fi
 
 # --- usage --------------------------------------------------------------------
 noarg_out="$(CHECK_PUBLISHED_ROOT="$good/local" "$CHECK" 2>&1)"

--- a/packaging/tests/check-release.test.sh
+++ b/packaging/tests/check-release.test.sh
@@ -157,6 +157,75 @@ expect_fail "ghVersion not bumped across the move" "$migrate_forgot" v0.3.0 "ghV
 no_manifest="$(make_repo nomanifest "0.2.0:2:v0.2.0:none" "0.3.0:3:v0.3.0:root")"
 expect_fail "previous tag has no manifest in either location" "$no_manifest" v0.3.0 "cannot read"
 
+# --- the tag on an unmerged release branch -----------------------------------
+# The release sequence publishes BEFORE the bump lands on master, so that the
+# beacon on master never announces a version whose asset is not up yet. The tag
+# is therefore created on the release branch, and master gets the bump only
+# afterwards — as a squash merge, at a DIFFERENT sha, so the tagged commit never
+# enters master's history at all. A previous-tag lookup that walks master's
+# ancestry walks straight past it, and the miss fails OPEN: the next release is
+# compared against the release before last, so a forgotten bump sails through.
+# See docs/superpowers/specs/2026-08-31-release-ordering-design.md.
+
+write_manifest() {
+  local d="$1" version="$2" ghversion="$3"
+  rm -f "$d/Info.json" "$d/plugin/Info.json"
+  cat > "$d/Info.json" <<JSON
+{"name":"AirPlay","identifier":"dev.faruk.iina-airplay","version":"$version",
+ "ghRepo":"ozykhan/iina-airplay","ghVersion":$ghversion,"entry":"main.js"}
+JSON
+}
+
+# Tags version/ghversion on a branch cut from master. merge=squash then puts the
+# same content on master as a NEW commit, exactly as `gh pr merge --squash`
+# leaves it; merge=no leaves the tag on an unmerged branch, which is the state
+# the gate sees at the moment the tag is pushed. Split declarations — see the
+# bash 3.2 note in Global Constraints.
+cut_on_branch() {
+  local d="$1" version="$2" ghversion="$3" tag="$4" merge="$5"
+  git -C "$d" checkout -q -B "release/$tag" master
+  write_manifest "$d" "$version" "$ghversion"
+  git -C "$d" add -A
+  git -C "$d" commit -q -m "release: $version"
+  git -C "$d" tag "$tag"
+  if [ "$merge" = squash ]; then
+    git -C "$d" checkout -q master
+    write_manifest "$d" "$version" "$ghversion"
+    git -C "$d" add -A
+    git -C "$d" commit -q -m "release: $version (squashed)"
+  fi
+  # merge=no deliberately leaves the checkout ON the release branch: the gate
+  # reads the manifest out of the working tree, and CI runs it with the tag
+  # checked out. Leaving it on master would test master's manifest against the
+  # branch's tag, which is a different (and always failing) question.
+}
+
+# The ordinary case: tag pushed from the branch, bump correct.
+onbranch="$(make_repo onbranch "0.2.0:2:v0.2.0:root")"
+cut_on_branch "$onbranch" 0.3.0 3 v0.3.0 no
+expect_ok "tag on an unmerged branch, ghVersion increased" "$onbranch" v0.3.0 "OK"
+
+# THE regression. v0.3.0 was cut on a branch and squash-merged, so it is not in
+# master's history; v0.4.0 then forgets to bump past it. A reachability lookup
+# finds v0.2.0 and waves 3 > 2 through, stranding every user who took v0.3.0.
+squashed="$(make_repo squashed "0.2.0:2:v0.2.0:root")"
+cut_on_branch "$squashed" 0.3.0 3 v0.3.0 squash
+cut_on_branch "$squashed" 0.4.0 3 v0.4.0 no
+expect_fail "ghVersion not bumped past a squash-merged previous tag" "$squashed" v0.4.0 "ghVersion"
+
+# Gating before the tag exists — what a maintainer runs locally to check the
+# bump before pushing anything. The lookup must still find the previous tag;
+# reporting "first release" here is a skip dressed up as reassurance.
+pretag="$(make_repo pretag "0.2.0:2:v0.2.0:root" "0.3.0:2::root")"
+expect_fail "ghVersion not bumped, gated before the tag exists" "$pretag" v0.3.0 "ghVersion"
+
+# The sort must be version-aware, not lexical: descending ASCII puts v0.9.0
+# above v0.10.0, which would compare this release against the wrong one and let
+# a stale ghVersion through.
+tenth="$(make_repo tenth "0.9.0:9:v0.9.0:root" "0.10.0:10:v0.10.0:root")"
+cut_on_branch "$tenth" 0.11.0 10 v0.11.0 no
+expect_fail "v0.10.0 outranks v0.9.0 in the previous-tag lookup" "$tenth" v0.11.0 "ghVersion"
+
 if [ "$fails" -ne 0 ]; then
   echo "$fails check-release.sh test(s) failed"
   exit 1


### PR DESCRIPTION
Closes the ~10 minute window that cutting v0.3.0 opened, in which `master`'s
beacon announced `0.3.0` while `releases/latest` still served the `0.2.0`
asset — so every update check in the gap offered existing installs an update
and handed them the release they already had.

## Why the obvious fix is wrong

Letting the release workflow rewrite `Info.json` on `master` as a last step
would be worse than the gap. IINA compares `master`'s `ghVersion` against **the
installed package's own** (1.4.4, `JavascriptPlugin.swift`, `checkForUpdates`):

```swift
if let ghVersion = githubVersion, ...          // this install's own number
   newGHVersion > ghVersion { handler(newVersion) }
```

If the shipped package kept the old number, `master` would compare greater
forever: an update prompt on every check, re-downloading the same file.

## What changes

The bump stays in the tagged tree; only its **arrival on `master`** moves. Tag
the release branch, publish, then merge. The skew that leaves runs the harmless
way round:

| State | Existing installs | New installs |
| --- | --- | --- |
| `master` ahead of `releases/latest` | offered an update, handed the **old** asset | fine |
| `releases/latest` ahead of `master` | no update offered yet; they wait | correct version, correctly told they are current |

- **`check-published.sh --release-only`** gates the merge — the one irreversible
  step, and until now the only one with no machine check in front of it. It
  skips the raw fetch outright rather than fetching and ignoring it, and its
  success line says `master` was NOT checked so it cannot be read as the full
  gate.
- **`check-release.sh` takes the highest tag by version sort**, not the nearest
  reachable one. Tagging a branch and squash-merging leaves the tag outside
  `master`'s history, so the old lookup walked past it to the release before
  last and compared against a lower `ghVersion` — failing **open**. It also now
  works before the tag exists, where it used to report "first release" and skip.

## Verification

`make test` passes. Both new suites drive the real scripts against fixtures; the
two tests that matter were written first and watched to fail:

- `ghVersion not bumped past a squash-merged previous tag` — the fail-open hole,
  reproduced (the gate accepted `ghVersion 3` for `v0.4.0` when `v0.3.0` shipped 3)
- `ghVersion not bumped, gated before the tag exists` — reported "first release"
  and skipped

Also run live against this repo: `--release-only`, the full gate, and an unknown
flag all behave. Design notes in `docs/superpowers/specs/2026-08-31-release-ordering-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)