### PR TITLE
docs: describe the start-position behaviour the mirror actually implements

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ macOS 12+ · any AirPlay 2 receiver · MIT · everything bundled, nothing downlo
 | --------------- | --------------------------------------------------------------------------------------------------------------------------- |
 | macOS 15+       | Grant IINA the **Local Network** permission on first cast, or the TV can't reach the stream                                 |
 | Image subtitles | PGS/VOBSUB are dropped with a notice rather than burned in. SRT/ASS work                                                    |
-| Start position  | Playback starts at the beginning of the file, not your current position — the trade for a fully seekable timeline on the TV |
+| Start position  | The TV starts from the beginning, then jumps to where IINA was once packaging has reached that point. Best-effort: if the TV ends up elsewhere, IINA follows the TV |
 
 <details>
 <summary><b>Why this is a handoff and not a mirror</b></summary>

--- a/docs/index.html
+++ b/docs/index.html
@@ -188,7 +188,7 @@
       <table>
         <tr><th scope="row">macOS 15+</th><td>Grant IINA the <strong>Local Network</strong> permission on first cast, or the TV can't reach the stream.</td></tr>
         <tr><th scope="row">Image subtitles</th><td>PGS/VOBSUB are dropped with a notice rather than burned in. SRT/ASS work.</td></tr>
-        <tr><th scope="row">Start position</th><td>Playback starts at the beginning of the file, not your current position. That is the trade for a fully seekable timeline on the TV.</td></tr>
+        <tr><th scope="row">Start position</th><td>The TV starts from the beginning, then jumps to where IINA was once packaging has reached that point. Best-effort: if the TV ends up elsewhere, IINA follows the TV.</td></tr>
       </table>
     </div>
   </section>


### PR DESCRIPTION
## What

The README limits table and the landing page's copy of it said playback starts at the beginning of the file, not the current position. That predates the muted mirror: `sidebar.html` now seeks the TV to where IINA was once packaging has reached that point (`initialSeekPending`), best-effort, and `mirrorOnTvState` follows the TV if it lands elsewhere.

Both rows now describe that behaviour.

## Where it came from

Found during an architecture review of the codebase; the review also filed #12, #13, #14 and #15 for the runtime findings. This PR is docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)