### PR TITLE
helper: sweep the HLS remux on every exit path, not just the next start

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,12 @@ macOS 12+ · any AirPlay 2 receiver · MIT · everything bundled, nothing downlo
 
 ### Limits, up front
 
-|                 |                                                                                                                             |
-| --------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| macOS 15+       | Grant IINA the **Local Network** permission on first cast, or the TV can't reach the stream                                 |
-| Image subtitles | PGS/VOBSUB are dropped with a notice rather than burned in. SRT/ASS work                                                    |
-| Start position  | Playback starts at the beginning of the file, not your current position — the trade for a fully seekable timeline on the TV |
+|                 |                                                                                                                                                          |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| macOS 15+       | Grant IINA the **Local Network** permission on first cast, or the TV can't reach the stream                                                              |
+| Image subtitles | PGS/VOBSUB are dropped with a notice rather than burned in. SRT/ASS work                                                                                 |
+| Start position  | Playback starts at the beginning of the file, not your current position — the trade for a fully seekable timeline on the TV                              |
+| Disk space      | A cast writes a second copy of the file (the HLS remux) to IINA's temp directory for as long as it runs; it is deleted when the cast stops or IINA quits |
 
 <details>
 <summary><b>Why this is a handoff and not a mirror</b></summary>

--- a/docs/feasibility.md
+++ b/docs/feasibility.md
@@ -95,6 +95,11 @@ build recipe and the compliance obligations are in `docs/distribution.md`.
   Remote URLs as *sources* are declined: the bundled ffmpeg is built `--disable-network`.
 - No frame-accurate position sync between IINA and the Apple TV. The muted mirror corrects drift
   toward the TV rather than trying to be sample-exact.
+- **A cast costs disk for its duration.** The remux is a byte-for-byte copy of the video and audio
+  bitstreams into `@tmp/hls`, so a UHD remux means tens of gigabytes of temp while the cast runs.
+  `-hls_playlist_type event` is what makes the TV timeline seekable, so segments cannot be expired
+  mid-cast; instead the helper sweeps the directory on every exit path — stop, IINA quitting or
+  crashing, a failed cast — and again at the next start in case it was killed outright.
 - **Gatekeeper — resolved, not open.** A binary inside a package IINA downloads and extracts
   itself picks up only `com.apple.provenance`, never `com.apple.quarantine`, so ad-hoc signing
   is enough and no Developer ID is needed. Verified against IINA's source *and* by experiment,

--- a/docs/index.html
+++ b/docs/index.html
@@ -189,6 +189,7 @@
         <tr><th scope="row">macOS 15+</th><td>Grant IINA the <strong>Local Network</strong> permission on first cast, or the TV can't reach the stream.</td></tr>
         <tr><th scope="row">Image subtitles</th><td>PGS/VOBSUB are dropped with a notice rather than burned in. SRT/ASS work.</td></tr>
         <tr><th scope="row">Start position</th><td>Playback starts at the beginning of the file, not your current position. That is the trade for a fully seekable timeline on the TV.</td></tr>
+        <tr><th scope="row">Disk space</th><td>A cast writes a second copy of the file (the HLS remux) to IINA's temp directory for as long as it runs. It is deleted when the cast stops or IINA quits.</td></tr>
       </table>
     </div>
   </section>

--- a/helper/cleanup.go
+++ b/helper/cleanup.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// castArtifacts are the files a cast writes into the output directory:
+// media and subtitle playlists, the fMP4 init segment, media segments and
+// WebVTT segments. The pidfile is deliberately not here — it belongs to
+// the process lifecycle, not the cast.
+var castArtifacts = []string{"index.m3u8", "master.m3u8", "*_vtt.m3u8", "*.vtt", "init.mp4", "seg_*.m4s"}
+
+// cleanOutDir removes every cast artifact from dir. A remux is a second
+// copy of the source's bitstreams, so this runs on every exit path, not
+// just at the next start (issue #12). Missing files and a missing dir are
+// fine; errors are ignored because there is nothing useful to do with them
+// on the way out.
+func cleanOutDir(dir string) {
+	for _, pat := range castArtifacts {
+		matches, _ := filepath.Glob(filepath.Join(dir, pat))
+		for _, m := range matches {
+			os.Remove(m)
+		}
+	}
+}

--- a/helper/cleanup_test.go
+++ b/helper/cleanup_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// cleanOutDir must remove everything a cast writes — playlists, the fMP4
+// init segment, media segments, the WebVTT rendition — and nothing else:
+// the pidfile belongs to the process lifecycle, and a stray file the user
+// dropped in the directory is not ours to touch.
+func TestCleanOutDirRemovesCastArtifactsOnly(t *testing.T) {
+	dir := t.TempDir()
+	artifacts := []string{"index.m3u8", "master.m3u8", "index_vtt.m3u8", "init.mp4", "seg_0000.m4s", "seg_0001.m4s", "seg_0000.vtt"}
+	keep := []string{"helper.pid", "notes.txt"}
+	for _, f := range append(append([]string{}, artifacts...), keep...) {
+		if err := os.WriteFile(filepath.Join(dir, f), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cleanOutDir(dir)
+	for _, f := range artifacts {
+		if _, err := os.Stat(filepath.Join(dir, f)); err == nil {
+			t.Errorf("%s survived the sweep", f)
+		}
+	}
+	for _, f := range keep {
+		if _, err := os.Stat(filepath.Join(dir, f)); err != nil {
+			t.Errorf("%s was removed but is not a cast artifact", f)
+		}
+	}
+}
+
+func TestCleanOutDirMissingDirIsNoop(t *testing.T) {
+	cleanOutDir(filepath.Join(t.TempDir(), "never-created")) // must not panic
+}

--- a/helper/job.go
+++ b/helper/job.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"syscall"
+	"time"
 )
 
 type JobConfig struct {
@@ -146,6 +147,9 @@ func RunJob(c JobConfig, out io.Writer) (func(), <-chan error) {
 
 	// Flag to track when job has completed (0 = running, 1 = done)
 	var jobDone atomic.Int32
+	// Closed once ffmpeg has exited and its result is on done, so stop can
+	// block until the process is really gone.
+	finished := make(chan struct{})
 
 	go func() {
 		sc := bufio.NewScanner(stdout)
@@ -173,8 +177,16 @@ func RunJob(c JobConfig, out io.Writer) (func(), <-chan error) {
 		// Mark job as done before sending to channel
 		jobDone.Store(1)
 		done <- werr
+		close(finished)
 	}()
 
+	// stop signals ffmpeg's process group and returns only once ffmpeg has
+	// exited: the caller sweeps the output directory next, and a segment
+	// ffmpeg was still flushing would otherwise reappear after the sweep.
+	// ffmpeg honours SIGTERM within a fraction of a second; a process that
+	// ignores it is SIGKILLed after a grace period chosen to stay inside the
+	// 3s the `stop` subcommand's TakeOver waits for the old instance.
+	// Safe to call more than once and after done has fired.
 	stop := func() {
 		// Only signal if job is still running
 		if jobDone.Load() == 0 {
@@ -183,6 +195,16 @@ func RunJob(c JobConfig, out io.Writer) (func(), <-chan error) {
 			if c, ok := stdout.(io.Closer); ok {
 				c.Close()
 			}
+		}
+		select {
+		case <-finished:
+			return
+		case <-time.After(2 * time.Second):
+		}
+		syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		select {
+		case <-finished:
+		case <-time.After(time.Second):
 		}
 	}
 	return stop, done

--- a/helper/job_test.go
+++ b/helper/job_test.go
@@ -246,3 +246,22 @@ func TestHasSubAndPlaylistName(t *testing.T) {
 		t.Fatalf("external-sub config: HasSub=%v playlist=%q", c.HasSub(), c.PlaylistName())
 	}
 }
+
+// stop() must not return until ffmpeg is gone: the caller sweeps the output
+// directory right after, and a segment ffmpeg is still flushing would come
+// back. A stub that ignores TERM (sleep inherits the ignored disposition)
+// proves the KILL escalation as well.
+func TestRunJobStopWaitsForExit(t *testing.T) {
+	stub := writeStubFFmpeg(t, `trap '' TERM; sleep 30`)
+	c := baseCfg()
+	c.FFmpeg = stub
+	var buf bytes.Buffer
+	stop, done := RunJob(c, &buf)
+	time.Sleep(200 * time.Millisecond)
+	stop()
+	select {
+	case <-done:
+	default:
+		t.Fatal("stop() returned before ffmpeg exited")
+	}
+}

--- a/helper/main.go
+++ b/helper/main.go
@@ -30,6 +30,10 @@ func main() {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
+		// The serving instance sweeps its own output on SIGTERM, and
+		// TakeOver waited for it. This catches a helper that died without
+		// sweeping (kill -9): after TakeOver nobody else owns the directory.
+		cleanOutDir(*out)
 	default:
 		fmt.Fprintf(os.Stderr, "unknown command %q\n", os.Args[1])
 		os.Exit(2)
@@ -63,7 +67,17 @@ func runServe(argv []string) {
 	// WritePidfile itself failed) — so every error exit leaves no stale
 	// pidfile behind, matching the WatchParent-triggered exit path below.
 	var pidfile string
+	// outOwned flips once TakeOver has cleared the output directory of any
+	// previous instance. Only then may an exit sweep it: before that, the
+	// files there may belong to a cast another instance is still serving.
+	outOwned := false
+	// stopJob is replaced once ffmpeg is running; fail can run before that.
+	stopJob := func() {}
 	fail := func(msg string) {
+		stopJob()
+		if outOwned {
+			cleanOutDir(c.OutDir)
+		}
 		if pidfile != "" {
 			os.Remove(pidfile)
 		}
@@ -84,12 +98,10 @@ func runServe(argv []string) {
 	if err := TakeOver(pidfile); err != nil {
 		fail("stale instance: " + err.Error())
 	}
-	for _, pat := range []string{"index.m3u8", "master.m3u8", "*_vtt.m3u8", "*.vtt", "init.mp4", "seg_*.m4s"} {
-		matches, _ := filepath.Glob(filepath.Join(c.OutDir, pat))
-		for _, m := range matches {
-			os.Remove(m)
-		}
-	}
+	outOwned = true
+	// Every exit path below sweeps, so this only matters for a previous
+	// instance that died without getting to its own sweep (kill -9).
+	cleanOutDir(c.OutDir)
 	if err := WritePidfile(pidfile); err != nil {
 		fail(err.Error())
 	}
@@ -106,10 +118,19 @@ func runServe(argv []string) {
 		fail(err.Error())
 	}
 
-	stopJob, done := RunJob(c, os.Stdout)
+	var done <-chan error
+	stopJob, done = RunJob(c, os.Stdout)
+
+	// teardown is every non-error way out: stop ffmpeg (blocks until it has
+	// exited), then sweep. The remux leaves with the cast, not at the next
+	// one — a UHD remux is tens of gigabytes of temp (issue #12).
+	teardown := func() {
+		stopJob()
+		cleanOutDir(c.OutDir)
+	}
 
 	WatchParent(parent, func() {
-		stopJob()
+		teardown()
 		os.Remove(pidfile)
 		os.Exit(0)
 	})
@@ -151,7 +172,6 @@ func runServe(argv []string) {
 					ready = true
 					readyTick.Stop()
 				} else if time.Now().After(readyDeadline) {
-					stopJob()
 					fail("packaging produced no playlist within 120s")
 				}
 			}
@@ -171,10 +191,11 @@ func runServe(argv []string) {
 			}
 			// Keep serving completed VOD until killed.
 			<-sigs
+			teardown()
 			Emit(os.Stdout, "stopped", nil)
 			return
 		case <-sigs:
-			stopJob()
+			teardown()
 			Emit(os.Stdout, "stopped", nil)
 			return
 		}

--- a/helper/main_test.go
+++ b/helper/main_test.go
@@ -300,3 +300,137 @@ func waitReady(t *testing.T, stdout io.Reader, timeout time.Duration) string {
 		}
 	}
 }
+
+// castFiles is what a real cast leaves in the output directory: the
+// playlist, the fMP4 init segment and at least one media segment. Every
+// teardown path must remove all of them (issue #12: a stopped cast used to
+// leave the whole remux in temp until the next cast).
+var castFiles = []string{"index.m3u8", "init.mp4", "seg_0000.m4s"}
+
+// castingStub writes a stub ffmpeg that lays down castFiles in out and then
+// runs tail — how the stub idles or exits.
+func castingStub(t *testing.T, out, tail string) string {
+	t.Helper()
+	stub := filepath.Join(t.TempDir(), "ffmpeg")
+	script := fmt.Sprintf("#!/bin/sh\necho '#EXTM3U' > %[1]s/index.m3u8\necho init > %[1]s/init.mp4\necho seg > %[1]s/seg_0000.m4s\n%[2]s\n", out, tail)
+	if err := os.WriteFile(stub, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return stub
+}
+
+func startServe(t *testing.T, bin, out, stub string, parent int) (*exec.Cmd, io.Reader) {
+	t.Helper()
+	cmd := exec.Command(bin, "serve",
+		"-source", "/dev/null", "-out", out, "-ffmpeg", stub,
+		"-parent", fmt.Sprint(parent), "-duration", "60",
+		"-vcodec", "h264", "-acodec", "aac", "-achannels", "2", "-vmap", "0", "-amap", "1")
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { cmd.Process.Kill(); cmd.Wait() })
+	return cmd, stdout
+}
+
+func waitExit(t *testing.T, cmd *exec.Cmd, timeout time.Duration) {
+	t.Helper()
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		t.Fatalf("helper still running after %v", timeout)
+	}
+}
+
+func assertSwept(t *testing.T, out string) {
+	t.Helper()
+	for _, f := range append(append([]string{}, castFiles...), "helper.pid") {
+		if _, err := os.Stat(filepath.Join(out, f)); err == nil {
+			t.Errorf("%s left behind in the output dir", f)
+		}
+	}
+}
+
+func TestStopSweepsOutDir(t *testing.T) {
+	bin := buildHelper(t)
+	out := t.TempDir()
+	stub := castingStub(t, out, "trap 'exit 0' TERM\nsleep 60")
+	cmd, stdout := startServe(t, bin, out, stub, os.Getpid())
+	waitReady(t, stdout, 15*time.Second)
+	for _, f := range castFiles {
+		if _, err := os.Stat(filepath.Join(out, f)); err != nil {
+			t.Fatalf("stub did not write %s: %v", f, err)
+		}
+	}
+
+	if err := exec.Command(bin, "stop", "-out", out).Run(); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+	waitExit(t, cmd, 5*time.Second)
+	assertSwept(t, out)
+}
+
+// After ffmpeg has finished (VOD complete) the helper keeps serving until
+// killed — a distinct branch of the serve loop that must sweep too.
+func TestStopAfterPackagedSweepsOutDir(t *testing.T) {
+	bin := buildHelper(t)
+	out := t.TempDir()
+	stub := castingStub(t, out, "echo progress=end\nexit 0")
+	cmd, stdout := startServe(t, bin, out, stub, os.Getpid())
+	waitReady(t, stdout, 15*time.Second)
+	// Give the serve loop time to consume ffmpeg's exit before stopping.
+	time.Sleep(500 * time.Millisecond)
+
+	if err := exec.Command(bin, "stop", "-out", out).Run(); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+	waitExit(t, cmd, 5*time.Second)
+	assertSwept(t, out)
+}
+
+// IINA quitting (or crashing) is the other way a cast ends; the watchdog
+// path must sweep just like the signal path.
+func TestParentDeathSweepsOutDir(t *testing.T) {
+	bin := buildHelper(t)
+	out := t.TempDir()
+	parent := exec.Command("/bin/sleep", "60")
+	if err := parent.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { parent.Process.Kill(); parent.Wait() })
+	stub := castingStub(t, out, "trap 'exit 0' TERM\nsleep 60")
+	cmd, stdout := startServe(t, bin, out, stub, parent.Process.Pid)
+	waitReady(t, stdout, 15*time.Second)
+
+	parent.Process.Kill()
+	parent.Wait()
+	waitExit(t, cmd, 10*time.Second) // watchdog polls every 2s
+	assertSwept(t, out)
+}
+
+// A cast that fails part-way leaves partial segments; the error exit must
+// sweep them as well.
+func TestFailedCastSweepsOutDir(t *testing.T) {
+	bin := buildHelper(t)
+	out := t.TempDir()
+	stub := castingStub(t, out, "echo 'boom' >&2\nexit 1")
+	cmd, stdout := startServe(t, bin, out, stub, os.Getpid())
+	b, _ := io.ReadAll(stdout)
+	waitExit(t, cmd, 10*time.Second)
+	sawError := false
+	for _, line := range strings.Split(strings.TrimSpace(string(b)), "\n") {
+		var ev map[string]any
+		if json.Unmarshal([]byte(line), &ev) == nil && ev["event"] == "error" {
+			sawError = true
+		}
+	}
+	if !sawError {
+		t.Fatalf("expected an error event, got:\n%s", b)
+	}
+	assertSwept(t, out)
+}


### PR DESCRIPTION
Closes #12.

## What was wrong

A stopped cast left `init.mp4` and every `seg_*.m4s` (tens of gigabytes for a UHD remux) in `@tmp/hls` until the next cast replaced it. The only sweep ran at the start of `serve`; the SIGTERM branch, the post-VOD wait, the `WatchParent` callback, `fail` and the `stop` subcommand removed nothing but the pidfile.

One thing the issue did not cover: `RunJob`'s `stop` only signalled ffmpeg and returned, so a sweep placed right after it could race a segment ffmpeg was still flushing.

## What changed

- `helper/cleanup.go`: `cleanOutDir`, the start-time glob loop extracted unchanged.
- `helper/main.go`: sweep on every exit — both SIGTERM branches, the watchdog callback, `fail` (a failed cast leaves partial segments) and the `stop` subcommand. The start-time sweep stays for a helper that died with `kill -9`. `fail` only sweeps once `TakeOver` has succeeded, so a losing instance never deletes another instance's live cast.
- `helper/job.go`: `stop` blocks until ffmpeg has exited, SIGTERM then SIGKILL after 2s, which stays inside the 3s the `stop` subcommand's `TakeOver` waits for the old instance.
- README limits table, `docs/index.html` and `docs/feasibility.md`: a cast writes a second copy of the file to temp for its duration.

## Tests

Written first and watched fail:

- `TestCleanOutDirRemovesCastArtifactsOnly` / `TestCleanOutDirMissingDirIsNoop`
- `TestRunJobStopWaitsForExit` — a TERM-ignoring stub proves stop waits and escalates to KILL
- `TestStopSweepsOutDir`, `TestStopAfterPackagedSweepsOutDir`, `TestParentDeathSweepsOutDir`, `TestFailedCastSweepsOutDir` — drive the built helper binary through each teardown path

Full Go suite (including the real-ffmpeg e2e tests) and the whole `make test` chain pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
