### PR TITLE
helper: advertise the default-route address, not the first interface

### DIFF
--- a/helper/netinfo.go
+++ b/helper/netinfo.go
@@ -23,10 +23,43 @@ func pickIPv4(addrs []net.Addr) string {
 	return ""
 }
 
-func LanIP() (string, error) {
+// defaultRouteIP asks the kernel which local address it would use to reach
+// an off-LAN host. Nothing is transmitted: a UDP "connect" only resolves the
+// route, and 192.0.2.1 is TEST-NET-1, reserved and never routable, so even a
+// stray write could not reach anything. Returns nil when there is no default
+// route at all (Wi-Fi to a TV-only network, say).
+func defaultRouteIP() net.IP {
+	c, err := net.Dial("udp4", "192.0.2.1:9")
+	if err != nil {
+		return nil
+	}
+	defer c.Close()
+	addr, ok := c.LocalAddr().(*net.UDPAddr)
+	if !ok {
+		return nil
+	}
+	return addr.IP
+}
+
+// chooseLanIP prefers the default-route address and falls back to walk. The
+// route is what an Apple TV on the same LAN can actually reach; the walk is
+// interface-index order, which lets a VPN tunnel, Docker bridge or second
+// NIC win purely by sorting first (issue #13).
+func chooseLanIP(route net.IP, walk func() string) string {
+	if route != nil {
+		if ip := pickIPv4([]net.Addr{&net.IPAddr{IP: route}}); ip != "" {
+			return ip
+		}
+	}
+	return walk()
+}
+
+// walkInterfaces returns the first up, non-loopback interface's usable IPv4,
+// in interface-index order — the pre-#13 behaviour, kept as the fallback.
+func walkInterfaces() string {
 	ifaces, err := net.Interfaces()
 	if err != nil {
-		return "", err
+		return ""
 	}
 	for _, iface := range ifaces {
 		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
@@ -37,8 +70,15 @@ func LanIP() (string, error) {
 			continue
 		}
 		if ip := pickIPv4(addrs); ip != "" {
-			return ip, nil
+			return ip
 		}
+	}
+	return ""
+}
+
+func LanIP() (string, error) {
+	if ip := chooseLanIP(defaultRouteIP(), walkInterfaces); ip != "" {
+		return ip, nil
 	}
 	return "", errors.New("no LAN IPv4 address found; the TV pulls the stream itself, so a routable address is required")
 }

--- a/helper/netinfo_test.go
+++ b/helper/netinfo_test.go
@@ -29,3 +29,34 @@ func TestPickIPv4(t *testing.T) {
 		}
 	}
 }
+
+func TestChooseLanIP(t *testing.T) {
+	walk := func(ips ...string) func() string {
+		return func() string {
+			if len(ips) == 0 {
+				return ""
+			}
+			return ips[0]
+		}
+	}
+	cases := []struct {
+		name  string
+		route net.IP
+		walk  func() string
+		want  string
+	}{
+		// The whole point of the issue: a VPN/bridge interface sorts first,
+		// but the kernel routes off-LAN traffic through the Wi-Fi address.
+		{"default route beats earlier-indexed interface", net.ParseIP("192.168.1.18"), walk("10.8.0.2", "192.168.1.18"), "192.168.1.18"},
+		{"no default route falls back to walk", nil, walk("10.8.0.2"), "10.8.0.2"},
+		{"loopback route falls back to walk", net.ParseIP("127.0.0.1"), walk("192.168.1.18"), "192.168.1.18"},
+		{"link-local route falls back to walk", net.ParseIP("169.254.10.1"), walk("192.168.1.18"), "192.168.1.18"},
+		{"v6 route falls back to walk", net.ParseIP("2001:db8::1"), walk("192.168.1.18"), "192.168.1.18"},
+		{"nothing anywhere is empty", nil, walk(), ""},
+	}
+	for _, c := range cases {
+		if got := chooseLanIP(c.route, c.walk); got != c.want {
+			t.Errorf("%s: got %q want %q", c.name, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #13.

`LanIP` walked `net.Interfaces()` in index order, so on a Mac with a VPN tunnel (`utun*`), a Docker/VM bridge (`bridge100`, `vmnet*`) or a second NIC, whichever sorted first went verbatim into the `ready` URL. The TV could not route to it and the cast failed as a media error after the pipeline had already reported `ready`.

## Change

- `defaultRouteIP()` asks the kernel which local address it would use to reach an off-LAN host via a UDP "connect" to `192.0.2.1:9` (TEST-NET-1, never routable). Nothing is transmitted.
- `chooseLanIP(route, walk)` prefers that address when it is a usable IPv4 (same loopback/link-local filter as before) and otherwise falls back to the old interface-index walk, which is kept as `walkInterfaces()` for a machine with no default route.
- `LanIP()` is unchanged for callers.

## Tests

`TestChooseLanIP` covers: default-route address winning over an earlier-indexed one, and fallback to the walk when the route is missing, loopback, link-local or IPv6.

```
go test ./...   ok  (25.6s, full helper suite incl. e2e)
```

On the maintainer's machine (single `en1`, default route) the probe and the walk return the same address, so behaviour there is unchanged.

Not included: the `-ip` manual override the issue mentions as a follow-up. It would also need a plugin-side preference to be reachable, so it is left for a separate change if the default-route lookup turns out not to cover a real case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
